### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Developer Kit for Claude Code
 
+[![Run in Smithery](https://smithery.ai/badge/skills/giuseppe-trisciuoglio)](https://smithery.ai/skills?ns=giuseppe-trisciuoglio&utm_source=github&utm_medium=badge)
+
+
 > A curated collection of reusable skills and agents for automating development tasks in Claude Code — focusing on
 > Java/Spring Boot patterns with extensibility to PHP, TypeScript, and Python
 


### PR DESCRIPTION
## Add skill discoverability badge

Your 48 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Agent Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/giuseppe-trisciuoglio)](https://smithery.ai/skills?ns=giuseppe-trisciuoglio&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.