### PR TITLE
56: fix(skills): Correct name mismatch in clean-architecture skill

### DIFF
--- a/plugins/developer-kit-php/skills/clean-architecture/SKILL.md
+++ b/plugins/developer-kit-php/skills/clean-architecture/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: clean-architecture-php
+name: clean-architecture
 description: Provides implementation patterns for Clean Architecture, Hexagonal Architecture (Ports & Adapters), and Domain-Driven Design in PHP 8.3+ with Symfony 7.x. Use when architecting enterprise PHP applications with entities/value objects/aggregates, refactoring legacy code to modern patterns, implementing domain-driven design with Symfony, or creating testable backends with clear separation of concerns.
 allowed-tools: Read, Write, Bash, Edit, Glob, Grep
 category: backend


### PR DESCRIPTION
## Summary
Implements #56: Corrected the YAML frontmatter `name` field mismatch in the `clean-architecture` skill for the `developer-kit-php` plugin.

- Changed frontmatter `name` from `clean-architecture-php` to `clean-architecture` to match the directory name
- Validation now passes without errors

## Changes
- `plugins/developer-kit-php/skills/clean-architecture/SKILL.md`: Fixed frontmatter `name` field

## Test Plan
- Ran validation: `python3 .skills-validator-check/validators/cli.py --all`
- Verified no validation errors (✓) for clean-architecture skill in developer-kit-php

Closes #56