### PR TITLE
55: fix(skills): Remove invalid frontmatter fields (category, tags, version)

### DIFF
--- a/plugins/developer-kit-ai/skills/chunking-strategy/SKILL.md
+++ b/plugins/developer-kit-ai/skills/chunking-strategy/SKILL.md
@@ -2,9 +2,6 @@
 name: chunking-strategy
 description: Provides optimal chunking strategies in RAG systems and document processing pipelines. Use when building retrieval-augmented generation systems, vector databases, or processing large documents that require breaking into semantically meaningful segments for embeddings and search.
 allowed-tools: Read, Write, Bash
-category: artificial-intelligence
-tags: [rag, chunking, vector-search, embeddings, document-processing]
-version: 1.0.0
 ---
 
 # Chunking Strategy for RAG Systems

--- a/plugins/developer-kit-ai/skills/prompt-engineering/SKILL.md
+++ b/plugins/developer-kit-ai/skills/prompt-engineering/SKILL.md
@@ -1,8 +1,5 @@
 ---
 name: prompt-engineering
-category: backend
-tags: [prompt-engineering, few-shot-learning, chain-of-thought, optimization, templates, system-prompts, llm-performance, ai-patterns]
-version: 1.0.0
 description: This skill should be used when creating, optimizing, or implementing advanced prompt patterns including few-shot learning, chain-of-thought reasoning, prompt optimization workflows, template systems, and system prompt design. It provides comprehensive frameworks for building production-ready prompts with measurable performance improvements.
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash
 ---

--- a/plugins/developer-kit-ai/skills/rag/SKILL.md
+++ b/plugins/developer-kit-ai/skills/rag/SKILL.md
@@ -2,9 +2,6 @@
 name: rag
 description: Provides patterns to build Retrieval-Augmented Generation (RAG) systems for AI applications with vector databases and semantic search. Use when implementing knowledge-grounded AI, building document Q&A systems, or integrating LLMs with external knowledge bases.
 allowed-tools: Read, Write, Bash
-category: ai-engineering
-tags: [rag, vector-databases, embeddings, retrieval, semantic-search]
-version: 1.0.0
 ---
 
 # RAG Implementation

--- a/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-auto-scaling/SKILL.md
+++ b/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-auto-scaling/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-cloudformation-auto-scaling
 description: Provides AWS CloudFormation patterns for Auto Scaling including EC2, ECS, and Lambda. Use when creating Auto Scaling groups, launch configurations, launch templates, scaling policies, lifecycle hooks, and predictive scaling. Covers template structure with Parameters, Outputs, Mappings, Conditions, cross-stack references, and best practices for high availability and cost optimization.
-category: aws
-tags: [aws, cloudformation, auto-scaling, ec2, ecs, lambda, infrastructure, iaac, scaling]
-version: 1.1.0
 allowed-tools: Read, Write, Bash
 ---
 

--- a/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-bedrock/SKILL.md
+++ b/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-bedrock/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-cloudformation-bedrock
 description: Provides AWS CloudFormation patterns for Amazon Bedrock resources including agents, knowledge bases, data sources, guardrails, prompts, flows, and inference profiles. Use when creating Bedrock agents with action groups, implementing RAG with knowledge bases, configuring vector stores, setting up content moderation guardrails, managing prompts, orchestrating workflows with flows, and configuring inference profiles for model optimization.
-category: aws
-tags: [aws, cloudformation, bedrock, ai, ml, agents, knowledge-base, rag, guardrail, inference, infrastructure, iaac]
-version: 1.0.0
 allowed-tools: Read, Write, Bash
 ---
 

--- a/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-cloudfront/SKILL.md
+++ b/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-cloudfront/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-cloudformation-cloudfront
 description: Provides AWS CloudFormation patterns for CloudFront distributions, origins (ALB, S3, Lambda@Edge, VPC Origins), CacheBehaviors, Functions, SecurityHeaders, parameters, Outputs and cross-stack references. Use when creating CloudFront distributions with CloudFormation, configuring multiple origins, implementing caching strategies, managing custom domains with ACM, configuring WAF, and optimizing performance.
-category: aws
-tags: [aws, cloudformation, cloudfront, cdn, content-delivery, distributions, origins, cache, waf, security]
-version: 1.0.0
 allowed-tools: Read, Write, Bash
 ---
 

--- a/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-cloudwatch/SKILL.md
+++ b/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-cloudwatch/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-cloudformation-cloudwatch
 description: Provides AWS CloudFormation patterns for CloudWatch monitoring, metrics, alarms, dashboards, logs, and observability. Use when creating CloudWatch metrics, alarms, dashboards, log groups, log subscriptions, anomaly detection, synthesized canaries, Application Signals, and implementing template structure with Parameters, Outputs, Mappings, Conditions, cross-stack references, and CloudWatch best practices for monitoring production infrastructure.
-category: aws
-tags: [aws, cloudformation, cloudwatch, monitoring, observability, metrics, alarms, logs, dashboards, infrastructure, iaac]
-version: 1.0.0
 allowed-tools: Read, Write, Bash
 ---
 

--- a/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-dynamodb/SKILL.md
+++ b/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-dynamodb/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-cloudformation-dynamodb
 description: Provides AWS CloudFormation patterns for DynamoDB tables, GSIs, LSIs, auto-scaling, and streams. Use when creating DynamoDB tables with CloudFormation, configuring primary keys, local/global secondary indexes, capacity modes (on-demand/provisioned), point-in-time recovery, encryption, TTL, and implementing template structure with Parameters, Outputs, Mappings, Conditions, cross-stack references.
-category: aws
-tags: [aws, cloudformation, dynamodb, nosql, database, serverless, tables, indexes, scaling, infrastructure, iaac]
-version: 1.0.0
 allowed-tools: Read, Write, Bash
 ---
 

--- a/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-ec2/SKILL.md
+++ b/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-ec2/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-cloudformation-ec2
 description: Provides AWS CloudFormation patterns for EC2 instances, Security Groups, IAM roles, and load balancers. Use when creating EC2 instances, SPOT instances, Security Groups, IAM roles for EC2, Application Load Balancers (ALB), Target Groups, and implementing template structure with Parameters, Outputs, Mappings, Conditions, and cross-stack references.
-category: aws
-tags: [aws, cloudformation, ec2, security-group, iam-role, alb, load-balancer, target-group, spot, infrastructure, iaac]
-version: 1.0.0
 allowed-tools: Read, Write, Bash
 ---
 

--- a/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-ecs/SKILL.md
+++ b/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-ecs/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-cloudformation-ecs
 description: Provides AWS CloudFormation patterns for ECS clusters, services, and task definitions. Use when creating ECS infrastructure with CloudFormation, configuring container definitions, scaling policies, service discovery, load balancing integration, and implementing template structure with Parameters, Outputs, Mappings, Conditions, cross-stack references, and blue/green deployments with CodeDeploy.
-category: aws
-tags: [aws, cloudformation, ecs, containers, docker, orchestration, infrastructure, iaac]
-version: 1.1.0
 allowed-tools: Read, Write, Bash
 ---
 

--- a/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-elasticache/SKILL.md
+++ b/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-elasticache/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-cloudformation-elasticache
 description: Provides AWS CloudFormation patterns for Amazon ElastiCache. Use when creating ElastiCache clusters (Redis, Memcached), replication groups, parameter groups, subnet groups, and implementing template structure with Parameters, Outputs, Mappings, Conditions, and cross-stack references for distributed caching infrastructure.
-category: aws
-tags: [aws, cloudformation, elasticache, redis, memcached, cache, infrastructure, iaac]
-version: 1.0.0
 allowed-tools: Read, Write, Bash
 ---
 

--- a/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-iam/SKILL.md
+++ b/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-iam/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-cloudformation-iam
 description: Provides AWS CloudFormation patterns for IAM users, roles, policies, and managed policies. Use when creating IAM resources with CloudFormation, implementing least privilege access, configuring cross-account access, setting up identity centers, managing permissions boundaries, and organizing template structure with Parameters, Outputs, Mappings, Conditions for secure infrastructure deployments.
-category: aws
-tags: [aws, cloudformation, iam, security, authentication, authorization, roles, policies, infrastructure, iaac]
-version: 1.0.0
 allowed-tools: Read, Write, Bash
 ---
 

--- a/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-lambda/SKILL.md
+++ b/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-lambda/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-cloudformation-lambda
 description: Provides AWS CloudFormation patterns for Lambda functions, layers, event sources, and integrations. Use when creating Lambda functions with CloudFormation, configuring API Gateway, Step Functions, EventBridge, SQS, SNS triggers, and implementing template structure with Parameters, Outputs, Mappings, Conditions, cross-stack references, and best practices for cold start optimization.
-category: aws
-tags: [aws, cloudformation, lambda, serverless, functions, api-gateway, step-functions, events, infrastructure, iaac]
-version: 1.0.0
 allowed-tools: Read, Write, Bash
 ---
 

--- a/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-rds/SKILL.md
+++ b/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-rds/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-cloudformation-rds
 description: Provides AWS CloudFormation patterns for Amazon RDS databases. Use when creating RDS instances (MySQL, PostgreSQL, Aurora), DB clusters, multi-AZ deployments, parameter groups, subnet groups, and implementing template structure with Parameters, Outputs, Mappings, Conditions, and cross-stack references.
-category: aws
-tags: [aws, cloudformation, rds, database, mysql, postgresql, aurora, mariadb, oracle, infrastructure, iaac]
-version: 1.0.0
 allowed-tools: Read, Write, Bash
 ---
 

--- a/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-s3/SKILL.md
+++ b/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-s3/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-cloudformation-s3
 description: Provides AWS CloudFormation patterns for Amazon S3. Use when creating S3 buckets, policies, versioning, lifecycle rules, and implementing template structure with Parameters, Outputs, Mappings, Conditions, and cross-stack references.
-category: aws
-tags: [aws, cloudformation, s3, storage, infrastructure, iaac]
-version: 1.0.0
 allowed-tools: Read, Write, Bash
 ---
 

--- a/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-security/SKILL.md
+++ b/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-security/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-cloudformation-security
 description: Provides AWS CloudFormation patterns for infrastructure security, secrets management, encryption, and secure data handling. Use when creating secure CloudFormation templates with AWS Secrets Manager, KMS encryption, secure parameters, IAM policies, VPC security groups, TLS/SSL certificates, and encrypted traffic configurations. Covers template structure, parameter best practices, cross-stack references, and defense-in-depth strategies.
-category: aws
-tags: [aws, cloudformation, security, kms, secrets-manager, iam, encryption, tls, ssl, vpc, infrastructure, iaac]
-version: 1.0.0
 allowed-tools: Read, Write, Bash
 ---
 

--- a/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-task-ecs-deploy-gh/SKILL.md
+++ b/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-task-ecs-deploy-gh/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-cloudformation-task-ecs-deploy-gh
 description: Provides patterns to deploy ECS tasks and services with GitHub Actions CI/CD. Use when building Docker images, pushing to ECR, updating ECS task definitions, deploying ECS services, integrating with CloudFormation stacks, configuring AWS OIDC authentication for GitHub Actions, and implementing production-ready container deployment pipelines. Supports ECS deployments with proper security (OIDC or IAM keys), multi-environment support, blue/green deployments, ECR private repositories with image scanning, and CloudFormation infrastructure updates.
-category: aws
-tags: [aws, cloudformation, github-actions, ecs, ecr, deployment, ci-cd, oidc, containers, docker, cd]
-version: 1.0.0
 allowed-tools: Read, Write, Bash
 ---
 

--- a/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-vpc/SKILL.md
+++ b/plugins/developer-kit-aws/skills/aws-cloudformation/aws-cloudformation-vpc/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-cloudformation-vpc
 description: Provides AWS CloudFormation patterns for VPC infrastructure. Use when creating VPCs, Subnets, Route Tables, NAT Gateways, Internet Gateways, and implementing template structure with Parameters, Outputs, Mappings, Conditions, and cross-stack references.
-category: aws
-tags: [aws, cloudformation, vpc, networking, infrastructure, terraform, iaac]
-version: 1.0.0
 allowed-tools: Read, Write, Bash
 ---
 

--- a/plugins/developer-kit-aws/skills/aws/aws-drawio-architecture-diagrams/SKILL.md
+++ b/plugins/developer-kit-aws/skills/aws/aws-drawio-architecture-diagrams/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-drawio-architecture-diagrams
 description: Provides professional AWS architecture diagram creation in draw.io XML format (.drawio files) using official AWS Architecture Icons (aws4 library). Use when creating AWS cloud architecture diagrams, infrastructure diagrams, network topology diagrams, serverless architectures, multi-tier application diagrams, VPC layouts, or any AWS visual diagram in draw.io format.
-category: aws
-tags: [aws, drawio, architecture, diagrams, infrastructure, cloud, visualization]
-version: 1.0.0
 allowed-tools: Read, Write, Bash
 ---
 

--- a/plugins/developer-kit-java/skills/aws-lambda-java-integration/SKILL.md
+++ b/plugins/developer-kit-java/skills/aws-lambda-java-integration/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: aws-lambda-java-integration
 description: Provides AWS Lambda integration patterns for Java with cold start optimization. Use when deploying Java functions to AWS Lambda, choosing between Micronaut and Raw Java approaches, optimizing cold starts below 1 second, configuring API Gateway or ALB integration, or implementing serverless Java applications. Triggers include "create lambda java", "deploy java lambda", "micronaut lambda aws", "java lambda cold start", "aws lambda java performance", "java serverless framework".
-category: backend
-tags: [aws, lambda, java, micronaut, serverless, cold-start]
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/aws-rds-spring-boot-integration/SKILL.md
+++ b/plugins/developer-kit-java/skills/aws-rds-spring-boot-integration/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-rds-spring-boot-integration
 description: Provides patterns to configure AWS RDS (Aurora, MySQL, PostgreSQL) with Spring Boot applications. Use when setting up datasources, connection pooling, security, and production-ready database configuration.
-category: aws
-tags: [aws, rds, aurora, spring-boot, spring-data-jpa, datasource, configuration, hikari, mysql, postgresql]
-version: 1.1.0
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/aws-sdk-java-v2-bedrock/SKILL.md
+++ b/plugins/developer-kit-java/skills/aws-sdk-java-v2-bedrock/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-sdk-java-v2-bedrock
 description: Provides Amazon Bedrock patterns using AWS SDK for Java 2.x. Use when working with foundation models (listing, invoking), text generation, image generation, embeddings, streaming responses, or integrating generative AI with Spring Boot applications.
-category: aws
-tags: [aws, bedrock, java, sdk, generative-ai, foundation-models]
-version: 2.0.0
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/aws-sdk-java-v2-core/SKILL.md
+++ b/plugins/developer-kit-java/skills/aws-sdk-java-v2-core/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-sdk-java-v2-core
 description: Provides core patterns and best practices for AWS SDK for Java 2.x. Use when configuring AWS service clients, setting up authentication, managing credentials, configuring timeouts, HTTP clients, or following AWS SDK best practices.
-category: aws
-tags: [aws, java, sdk, core, authentication, configuration]
-version: 1.1.0
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/aws-sdk-java-v2-dynamodb/SKILL.md
+++ b/plugins/developer-kit-java/skills/aws-sdk-java-v2-dynamodb/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-sdk-java-v2-dynamodb
 description: Provides Amazon DynamoDB patterns using AWS SDK for Java 2.x. Use when creating, querying, scanning, or performing CRUD operations on DynamoDB tables, working with indexes, batch operations, transactions, or integrating with Spring Boot applications.
-category: aws
-tags: [aws, dynamodb, java, sdk, nosql, database]
-version: 1.1.0
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/aws-sdk-java-v2-kms/SKILL.md
+++ b/plugins/developer-kit-java/skills/aws-sdk-java-v2-kms/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-sdk-java-v2-kms
 description: Provides AWS Key Management Service (KMS) patterns using AWS SDK for Java 2.x. Use when creating/managing encryption keys, encrypting/decrypting data, generating data keys, digital signing, key rotation, or integrating encryption into Spring Boot applications.
-category: aws
-tags: [aws, kms, java, sdk, encryption, security]
-version: 1.1.0
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/aws-sdk-java-v2-lambda/SKILL.md
+++ b/plugins/developer-kit-java/skills/aws-sdk-java-v2-lambda/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-sdk-java-v2-lambda
 description: Provides AWS Lambda patterns using AWS SDK for Java 2.x. Use when invoking Lambda functions, creating/updating functions, managing function configurations, working with Lambda layers, or integrating Lambda with Spring Boot applications.
-category: aws
-tags: [aws, lambda, java, sdk, serverless, functions]
-version: 1.1.0
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/aws-sdk-java-v2-messaging/SKILL.md
+++ b/plugins/developer-kit-java/skills/aws-sdk-java-v2-messaging/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-sdk-java-v2-messaging
 description: Provides AWS messaging patterns using AWS SDK for Java 2.x for SQS queues and SNS topics. Handles sending/receiving messages, FIFO queues, DLQ, subscriptions, and pub/sub patterns. Use when implementing messaging with SQS or SNS.
-category: aws
-tags: [aws, sqs, sns, java, sdk, messaging, pub-sub, queues, events]
-version: 1.1.0
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/aws-sdk-java-v2-rds/SKILL.md
+++ b/plugins/developer-kit-java/skills/aws-sdk-java-v2-rds/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-sdk-java-v2-rds
 description: Provides AWS RDS (Relational Database Service) management patterns using AWS SDK for Java 2.x. Use when creating, modifying, monitoring, or managing Amazon RDS database instances, snapshots, parameter groups, and configurations.
-category: aws
-tags: [aws, rds, database, java, sdk, postgresql, mysql, aurora, spring-boot]
-version: 1.1.0
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/aws-sdk-java-v2-s3/SKILL.md
+++ b/plugins/developer-kit-java/skills/aws-sdk-java-v2-s3/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-sdk-java-v2-s3
 description: Provides Amazon S3 patterns and examples using AWS SDK for Java 2.x. Use when working with S3 buckets, uploading/downloading objects, multipart uploads, presigned URLs, S3 Transfer Manager, object operations, or S3-specific configurations.
-category: aws
-tags: [aws, s3, java, sdk, storage, objects, transfer-manager, presigned-urls]
-version: 1.1.0
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/aws-sdk-java-v2-secrets-manager/SKILL.md
+++ b/plugins/developer-kit-java/skills/aws-sdk-java-v2-secrets-manager/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-sdk-java-v2-secrets-manager
 description: Provides AWS Secrets Manager patterns using AWS SDK for Java 2.x. Use when storing/retrieving secrets (passwords, API keys, tokens), rotating secrets automatically, managing database credentials, or integrating secret management into Spring Boot applications.
-category: aws
-tags: [aws, secrets-manager, java, sdk, security, credentials, spring-boot]
-version: 1.1.0
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/clean-architecture/SKILL.md
+++ b/plugins/developer-kit-java/skills/clean-architecture/SKILL.md
@@ -2,9 +2,6 @@
 name: clean-architecture
 description: Provides implementation patterns for Clean Architecture, Hexagonal Architecture (Ports & Adapters), and Domain-Driven Design in Java 21+ Spring Boot 3.5+ applications. Use when structuring layered architectures, separating domain logic from frameworks, implementing ports and adapters, creating entities/value objects/aggregates, or refactoring monolithic codebases for testability and maintainability.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
-category: backend
-tags: [clean-architecture, hexagonal-architecture, ddd, domain-driven-design, spring-boot, java, ports-adapters, layered-architecture]
-version: 1.0.0
 ---
 
 # Clean Architecture, Hexagonal Architecture & DDD for Spring Boot

--- a/plugins/developer-kit-java/skills/langchain4j-ai-services-patterns/SKILL.md
+++ b/plugins/developer-kit-java/skills/langchain4j-ai-services-patterns/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: langchain4j-ai-services-patterns
 description: Provides patterns to build declarative AI Services with LangChain4j using interface-based patterns, annotations, memory management, tools integration, and advanced application patterns. Use when implementing type-safe AI-powered features with minimal boilerplate code in Java applications.
-category: ai-development
-tags: [langchain4j, ai-services, annotations, declarative, tools, memory, function-calling, llm, java]
-version: 1.1.0
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/langchain4j-mcp-server-patterns/SKILL.md
+++ b/plugins/developer-kit-java/skills/langchain4j-mcp-server-patterns/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: langchain4j-mcp-server-patterns
 description: Provides Model Context Protocol (MCP) server implementation patterns with LangChain4j. Use when building MCP servers to extend AI capabilities with custom tools, resources, and prompt templates.
-category: ai-integration
-tags: [langchain4j, mcp, model-context-protocol, tools, resources, prompts, ai-services, java, spring-boot, enterprise]
-version: 1.1.0
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
 ---
 

--- a/plugins/developer-kit-java/skills/langchain4j-rag-implementation-patterns/SKILL.md
+++ b/plugins/developer-kit-java/skills/langchain4j-rag-implementation-patterns/SKILL.md
@@ -2,9 +2,6 @@
 name: langchain4j-rag-implementation-patterns
 description: Provides Retrieval-Augmented Generation (RAG) implementation patterns with LangChain4j. Handles document ingestion pipelines, embedding stores, vector search strategies, and knowledge-enhanced AI applications. Use when creating question-answering systems over document collections or AI assistants with external knowledge bases.
 allowed-tools: Read, Write, Bash
-category: ai-development
-tags: [langchain4j, rag, retrieval-augmented-generation, embedding, vector-search, document-ingestion, java]
-version: 1.1.0
 ---
 
 # LangChain4j RAG Implementation Patterns

--- a/plugins/developer-kit-java/skills/langchain4j-spring-boot-integration/SKILL.md
+++ b/plugins/developer-kit-java/skills/langchain4j-spring-boot-integration/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: langchain4j-spring-boot-integration
 description: Provides integration patterns for LangChain4j with Spring Boot. Handles auto-configuration, dependency injection, and Spring ecosystem integration. Use when embedding LangChain4j into Spring Boot applications.
-category: ai-development
-tags: [langchain4j, spring-boot, ai, llm, rag, chatbot, integration, configuration, java]
-version: 1.1.0
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/langchain4j-testing-strategies/SKILL.md
+++ b/plugins/developer-kit-java/skills/langchain4j-testing-strategies/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: langchain4j-testing-strategies
 description: Provides testing strategies for LangChain4j-powered applications. Handles mocking LLM responses, testing retrieval chains, and validating AI workflows. Use when testing AI-powered features reliably.
-category: backend
-tags: [langchain4j, testing, unit-tests, integration-tests, testcontainers, java, ai, llm, mock]
-version: 1.1.0
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/langchain4j-tool-function-calling-patterns/SKILL.md
+++ b/plugins/developer-kit-java/skills/langchain4j-tool-function-calling-patterns/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: langchain4j-tool-function-calling-patterns
 description: Provides tool and function calling patterns with LangChain4j. Handles defining tools, function calls, and LLM agent integration. Use when building agentic applications that interact with tools.
-category: ai-development
-tags: [langchain4j, tools, function-calling, "@Tool", ToolProvider, ToolExecutor, dynamic-tools, parameter-descriptions, java]
-version: 1.1.0
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
 ---
 

--- a/plugins/developer-kit-java/skills/langchain4j-vector-stores-configuration/SKILL.md
+++ b/plugins/developer-kit-java/skills/langchain4j-vector-stores-configuration/SKILL.md
@@ -2,9 +2,6 @@
 name: langchain4j-vector-stores-configuration
 description: Provides configuration patterns for LangChain4J vector stores in RAG applications. Use when building semantic search, integrating vector databases (PostgreSQL/pgvector, Pinecone, MongoDB, Milvus, Neo4j), implementing embedding storage/retrieval, setting up hybrid search, or optimizing vector database performance for production AI applications.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
-category: backend
-tags: [langchain4j, vector-stores, embeddings, rag, semantic-search, ai, llm, java, databases]
-version: 1.1.0
 ---
 
 # LangChain4J Vector Stores Configuration

--- a/plugins/developer-kit-java/skills/qdrant/SKILL.md
+++ b/plugins/developer-kit-java/skills/qdrant/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: qdrant
 description: Provides Qdrant vector database integration patterns with LangChain4j. Handles embedding storage, similarity search, and vector management for Java applications. Use when implementing vector-based retrieval for RAG systems, semantic search, or recommendation engines.
-category: backend
-tags: [qdrant, java, spring-boot, langchain4j, vector-search, ai, machine-learning]
-version: 1.2.0
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/spring-ai-mcp-server-patterns/SKILL.md
+++ b/plugins/developer-kit-java/skills/spring-ai-mcp-server-patterns/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: spring-ai-mcp-server-patterns
 description: Provides Model Context Protocol (MCP) server implementation patterns with Spring AI. Use when building MCP servers to extend AI capabilities with custom tools, resources, and prompt templates using Spring's official AI framework.
-category: ai-integration
-tags: [spring-ai, mcp, model-context-protocol, tools, function-calling, prompts, java, spring-boot, enterprise]
-version: 1.0.0
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/spring-boot-actuator/SKILL.md
+++ b/plugins/developer-kit-java/skills/spring-boot-actuator/SKILL.md
@@ -2,9 +2,6 @@
 name: spring-boot-actuator
 description: Provides patterns to configure Spring Boot Actuator for production-grade monitoring, health probes, secured management endpoints, and Micrometer metrics across JVM services. Use when setting up monitoring, health checks, or metrics for Spring Boot applications.
 allowed-tools: Read, Write, Bash
-category: backend
-tags: [spring-boot, actuator, monitoring, health-checks, metrics, production]
-version: 1.1.0
 ---
 
 # Spring Boot Actuator Skill

--- a/plugins/developer-kit-java/skills/spring-boot-cache/SKILL.md
+++ b/plugins/developer-kit-java/skills/spring-boot-cache/SKILL.md
@@ -2,9 +2,6 @@
 name: spring-boot-cache
 description: Provides patterns for enabling and operating the Spring Cache abstraction in Spring Boot. Use when implementing application-level caching for performance-sensitive workloads.
 allowed-tools: Read, Write, Bash
-category: backend
-tags: [spring-boot, caching, performance, cacheable, cache-managers]
-version: 1.1.0
 ---
 
 # Spring Boot Cache Abstraction

--- a/plugins/developer-kit-java/skills/spring-boot-crud-patterns/SKILL.md
+++ b/plugins/developer-kit-java/skills/spring-boot-crud-patterns/SKILL.md
@@ -2,9 +2,6 @@
 name: spring-boot-crud-patterns
 description: Provides repeatable CRUD workflows for Spring Boot 3 services with Spring Data JPA and feature-focused architecture. Use when modeling aggregates, repositories, controllers, and DTOs for REST APIs.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
-category: backend
-tags: [spring-boot, java, ddd, rest-api, crud, jpa, feature-architecture]
-version: 1.1.0
 ---
 
 # Spring Boot CRUD Patterns

--- a/plugins/developer-kit-java/skills/spring-boot-dependency-injection/SKILL.md
+++ b/plugins/developer-kit-java/skills/spring-boot-dependency-injection/SKILL.md
@@ -2,9 +2,6 @@
 name: spring-boot-dependency-injection
 description: Provides dependency injection patterns for Spring Boot projects covering constructor-first patterns, optional collaborator handling, bean selection, and validation practices. Use when configuring beans, wiring dependencies, or troubleshooting injection issues.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
-category: backend
-tags: [spring-boot, dependency-injection, constructor-injection, bean-configuration, autowiring, testing, java]
-version: 1.1.0
 ---
 
 # Spring Boot Dependency Injection

--- a/plugins/developer-kit-java/skills/spring-boot-event-driven-patterns/SKILL.md
+++ b/plugins/developer-kit-java/skills/spring-boot-event-driven-patterns/SKILL.md
@@ -2,9 +2,6 @@
 name: spring-boot-event-driven-patterns
 description: Provides Event-Driven Architecture (EDA) patterns in Spring Boot using ApplicationEvent, @EventListener, and Kafka. Use when building loosely-coupled microservices with domain events, transactional event listeners, and distributed messaging patterns.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
-category: backend
-tags: [spring-boot, java, event-driven, eda, kafka, messaging, domain-events, microservices, spring-cloud-stream]
-version: 1.1.0
 ---
 
 # Spring Boot Event-Driven Patterns

--- a/plugins/developer-kit-java/skills/spring-boot-openapi-documentation/SKILL.md
+++ b/plugins/developer-kit-java/skills/spring-boot-openapi-documentation/SKILL.md
@@ -2,9 +2,6 @@
 name: spring-boot-openapi-documentation
 description: Provides patterns to generate comprehensive REST API documentation using SpringDoc OpenAPI 3.0 and Swagger UI in Spring Boot 3.x applications. Use when setting up API documentation, configuring Swagger UI, adding OpenAPI annotations, implementing security documentation, or enhancing REST endpoints with examples and schemas.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
-category: backend
-tags: [spring-boot, openapi, swagger, api-documentation, springdoc]
-version: 1.1.0
 ---
 
 # Spring Boot OpenAPI Documentation with SpringDoc

--- a/plugins/developer-kit-java/skills/spring-boot-resilience4j/SKILL.md
+++ b/plugins/developer-kit-java/skills/spring-boot-resilience4j/SKILL.md
@@ -2,9 +2,6 @@
 name: spring-boot-resilience4j
 description: This skill should be used when implementing fault tolerance and resilience patterns in Spring Boot applications using the Resilience4j library. Apply this skill to add circuit breaker, retry, rate limiter, bulkhead, time limiter, and fallback mechanisms to prevent cascading failures, handle transient errors, and manage external service dependencies gracefully in microservices architectures.
 allowed-tools: Read, Write, Edit, Bash
-category: backend
-tags: [spring-boot, resilience4j, circuit-breaker, fault-tolerance, retry, bulkhead, rate-limiter]
-version: 1.1.0
 ---
 
 # Spring Boot Resilience4j Patterns

--- a/plugins/developer-kit-java/skills/spring-boot-rest-api-standards/SKILL.md
+++ b/plugins/developer-kit-java/skills/spring-boot-rest-api-standards/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: spring-boot-rest-api-standards
 description: Provides REST API design standards and best practices for Spring Boot projects. Use when creating or reviewing REST endpoints, DTOs, error handling, pagination, security headers, HATEOAS and architecture patterns.
-category: backend
-tags: [spring-boot, rest-api, dto, validation, error-handling, pagination, hateoas, architecture, java]
-version: 1.1.0
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/spring-boot-saga-pattern/SKILL.md
+++ b/plugins/developer-kit-java/skills/spring-boot-saga-pattern/SKILL.md
@@ -2,9 +2,6 @@
 name: spring-boot-saga-pattern
 description: Provides distributed transaction patterns using the Saga Pattern in Spring Boot microservices. Use when building microservices requiring transaction management across multiple services, handling compensating transactions, ensuring eventual consistency, or implementing choreography or orchestration-based sagas with Spring Boot, Kafka, or Axon Framework.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
-category: backend
-tags: [spring-boot, saga, distributed-transactions, choreography, orchestration, microservices]
-version: 1.1.0
 ---
 
 # Spring Boot Saga Pattern

--- a/plugins/developer-kit-java/skills/spring-boot-security-jwt/SKILL.md
+++ b/plugins/developer-kit-java/skills/spring-boot-security-jwt/SKILL.md
@@ -2,9 +2,6 @@
 name: spring-boot-security-jwt
 description: Provides JWT authentication and authorization patterns for Spring Boot 3.5.x covering token generation with JJWT, Bearer/cookie authentication, database/OAuth2 integration, and RBAC/permission-based access control using Spring Security 6.x. Use when implementing authentication or authorization in Spring Boot applications.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
-category: backend
-tags: [spring-boot, spring-security, jwt, authentication, authorization, rbac, oauth2, jjwt]
-version: 1.0.0
 ---
 
 # Spring Boot JWT Security

--- a/plugins/developer-kit-java/skills/spring-boot-test-patterns/SKILL.md
+++ b/plugins/developer-kit-java/skills/spring-boot-test-patterns/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: spring-boot-test-patterns
 description: Provides comprehensive testing patterns for Spring Boot applications including unit, integration, slice, and container-based testing with JUnit 5, Mockito, Testcontainers, and performance optimization. Use when implementing robust test suites for Spring Boot applications.
-category: testing
-tags: [spring-boot, java, testing, junit5, mockito, testcontainers, integration-testing, unit-testing, test-slices]
-version: 1.5.0
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/spring-data-jpa/SKILL.md
+++ b/plugins/developer-kit-java/skills/spring-data-jpa/SKILL.md
@@ -2,9 +2,6 @@
 name: spring-data-jpa
 description: Provides patterns to implement persistence layers with Spring Data JPA. Use when creating repositories, configuring entity relationships, writing queries (derived and @Query), setting up pagination, database auditing, transactions, UUID primary keys, multiple databases, and database indexing.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
-category: backend
-tags: [spring-data, jpa, database, hibernate, orm, persistence]
-version: 1.2.0
 ---
 
 # Spring Data JPA

--- a/plugins/developer-kit-java/skills/spring-data-neo4j/SKILL.md
+++ b/plugins/developer-kit-java/skills/spring-data-neo4j/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: spring-data-neo4j
 description: Provides Spring Data Neo4j integration patterns for graph database development. Use when working with Neo4j graph databases, node entities, relationships, Cypher queries, reactive Neo4j operations, or Spring Data Neo4j repositories.
-version: 1.1.0
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
-category: backend
-tags: [spring-data, neo4j, graph-database, database, java, spring-boot]
 ---
 
 # Spring Data Neo4j Integration Patterns

--- a/plugins/developer-kit-java/skills/unit-test-application-events/SKILL.md
+++ b/plugins/developer-kit-java/skills/unit-test-application-events/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: unit-test-application-events
 description: Provides patterns for testing Spring application events (ApplicationEvent) with @EventListener and ApplicationEventPublisher. Handles event publishing, listening, and async event handling in Spring Boot applications. Use when validating event-driven workflows in your Spring Boot services.
-category: testing
-tags: [junit-5, application-events, event-driven, listeners, publishers]
-version: 1.0.1
 allowed-tools: Read, Write, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/unit-test-bean-validation/SKILL.md
+++ b/plugins/developer-kit-java/skills/unit-test-bean-validation/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: unit-test-bean-validation
 description: Provides patterns for unit testing Jakarta Bean Validation (@Valid, @NotNull, @Min, @Max, etc.) with custom validators and constraint violations. Validates logic without Spring context. Use when ensuring data integrity and validation rules are correct.
-category: testing
-tags: [junit-5, validation, bean-validation, jakarta-validation, constraints]
-version: 1.0.1
 allowed-tools: Read, Write, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/unit-test-boundary-conditions/SKILL.md
+++ b/plugins/developer-kit-java/skills/unit-test-boundary-conditions/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: unit-test-boundary-conditions
 description: Edge case and boundary testing patterns for unit tests. Testing minimum/maximum values, null cases, empty collections, and numeric precision. Pure JUnit 5 unit tests. Use when ensuring code handles limits and special cases correctly.
-category: testing
-tags: [junit-5, boundary-testing, edge-cases, parameterized-test]
-version: 1.0.1
 allowed-tools: Read, Write, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/unit-test-caching/SKILL.md
+++ b/plugins/developer-kit-java/skills/unit-test-caching/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: unit-test-caching
 description: Provides patterns for unit testing caching behavior using Spring Cache annotations (@Cacheable, @CachePut, @CacheEvict). Use when validating cache configuration and cache hit/miss scenarios.
-category: testing
-tags: [junit-5, caching, cacheable, cache-evict, cache-put]
-version: 1.0.1
 allowed-tools: Read, Write, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/unit-test-config-properties/SKILL.md
+++ b/plugins/developer-kit-java/skills/unit-test-config-properties/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: unit-test-config-properties
 description: Provides patterns for unit testing @ConfigurationProperties classes with @ConfigurationPropertiesTest. Use when validating application configuration binding and validation.
-category: testing
-tags: [junit-5, configuration-properties, spring-profiles, property-binding]
-version: 1.0.1
 allowed-tools: Read, Write, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/unit-test-controller-layer/SKILL.md
+++ b/plugins/developer-kit-java/skills/unit-test-controller-layer/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: unit-test-controller-layer
 description: Provides patterns for unit testing REST controllers using MockMvc and @WebMvcTest. Validates request/response mapping, validation, and exception handling. Use when testing web layer endpoints in isolation.
-category: testing
-tags: [junit-5, mockito, unit-testing, controller, rest, mockmvc]
-version: 1.0.1
 allowed-tools: Read, Write, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/unit-test-exception-handler/SKILL.md
+++ b/plugins/developer-kit-java/skills/unit-test-exception-handler/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: unit-test-exception-handler
 description: Provides patterns for unit testing @ExceptionHandler and @ControllerAdvice for global exception handling. Use when validating error response formatting and HTTP status codes.
-category: testing
-tags: [junit-5, exception-handler, controller-advice, error-handling, mockmvc]
-version: 1.0.1
 allowed-tools: Read, Write, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/unit-test-json-serialization/SKILL.md
+++ b/plugins/developer-kit-java/skills/unit-test-json-serialization/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: unit-test-json-serialization
 description: Provides patterns for unit testing JSON serialization/deserialization with Jackson and @JsonTest. Use when validating JSON mapping, custom serializers, and date format handling.
-category: testing
-tags: [junit-5, json-test, jackson, serialization, deserialization]
-version: 1.0.1
 allowed-tools: Read, Write, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/unit-test-mapper-converter/SKILL.md
+++ b/plugins/developer-kit-java/skills/unit-test-mapper-converter/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: unit-test-mapper-converter
 description: Provides patterns for unit testing mappers and converters (MapStruct, custom mappers). Validates object transformation logic in isolation. Use when ensuring correct data transformation between DTOs and domain objects.
-category: testing
-tags: [junit-5, mapstruct, mapper, dto, entity, converter]
-version: 1.0.1
 allowed-tools: Read, Write, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/unit-test-parameterized/SKILL.md
+++ b/plugins/developer-kit-java/skills/unit-test-parameterized/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: unit-test-parameterized
 description: Provides parameterized testing patterns with @ParameterizedTest, @ValueSource, @CsvSource. Enables running a single test method with multiple input combinations. Use when testing multiple scenarios with similar logic.
-category: testing
-tags: [junit-5, parameterized-test, value-source, csv-source, method-source]
-version: 1.0.1
 allowed-tools: Read, Write, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/unit-test-scheduled-async/SKILL.md
+++ b/plugins/developer-kit-java/skills/unit-test-scheduled-async/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: unit-test-scheduled-async
 description: Provides patterns for unit testing scheduled and async tasks using @Scheduled and @Async. Handles mocking task execution and timing. Use when validating asynchronous operations and scheduling behavior.
-category: testing
-tags: [junit-5, scheduled, async, concurrency, completablefuture]
-version: 1.0.1
 allowed-tools: Read, Write, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/unit-test-security-authorization/SKILL.md
+++ b/plugins/developer-kit-java/skills/unit-test-security-authorization/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: unit-test-security-authorization
 description: Provides patterns for unit testing Spring Security with @PreAuthorize, @Secured, @RolesAllowed. Validates role-based access control and authorization policies. Use when testing security configurations and access control logic.
-category: testing
-tags: [junit-5, spring-security, authorization, roles, preauthorize, mockmvc]
-version: 1.0.1
 allowed-tools: Read, Write, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/unit-test-service-layer/SKILL.md
+++ b/plugins/developer-kit-java/skills/unit-test-service-layer/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: unit-test-service-layer
 description: Provides patterns for unit testing service layer with Mockito. Validates business logic in isolation by mocking dependencies. Use when testing service behaviors and business logic without database or external services.
-category: testing
-tags: [junit-5, mockito, unit-testing, service-layer, business-logic]
-version: 1.0.1
 allowed-tools: Read, Write, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/unit-test-utility-methods/SKILL.md
+++ b/plugins/developer-kit-java/skills/unit-test-utility-methods/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: unit-test-utility-methods
 description: Provides patterns for unit testing utility/helper classes and static methods. Validates pure functions and helper logic. Use when verifying utility code correctness.
-category: testing
-tags: [junit-5, unit-testing, utility, static-methods, pure-functions]
-version: 1.0.1
 allowed-tools: Read, Write, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-java/skills/unit-test-wiremock-rest-api/SKILL.md
+++ b/plugins/developer-kit-java/skills/unit-test-wiremock-rest-api/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: unit-test-wiremock-rest-api
 description: Provides patterns for unit testing external REST APIs using WireMock to mock HTTP endpoints. Use when testing service integrations with external APIs.
-category: testing
-tags: [junit-5, wiremock, unit-testing, rest-api, mocking, http-stubbing]
-version: 1.0.1
 allowed-tools: Read, Write, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-php/skills/aws-lambda-php-integration/SKILL.md
+++ b/plugins/developer-kit-php/skills/aws-lambda-php-integration/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: aws-lambda-php-integration
 description: Provides AWS Lambda integration patterns for PHP with Symfony using the Bref framework. Use when deploying PHP/Symfony applications to AWS Lambda, optimizing cold starts, configuring API Gateway integration, or implementing serverless PHP applications with Bref. Triggers include "create lambda php", "deploy symfony lambda", "bref lambda aws", "php lambda cold start", "aws lambda php performance", "symfony serverless", "php serverless framework".
-category: backend
-tags: [aws, lambda, php, symfony, bref, serverless, cold-start]
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash
 ---
 

--- a/plugins/developer-kit-php/skills/clean-architecture/SKILL.md
+++ b/plugins/developer-kit-php/skills/clean-architecture/SKILL.md
@@ -2,9 +2,6 @@
 name: clean-architecture
 description: Provides implementation patterns for Clean Architecture, Hexagonal Architecture (Ports & Adapters), and Domain-Driven Design in PHP 8.3+ with Symfony 7.x. Use when architecting enterprise PHP applications with entities/value objects/aggregates, refactoring legacy code to modern patterns, implementing domain-driven design with Symfony, or creating testable backends with clear separation of concerns.
 allowed-tools: Read, Write, Bash, Edit, Glob, Grep
-category: backend
-tags: [clean-architecture, hexagonal-architecture, ddd, domain-driven-design, php, symfony, ports-adapters]
-version: 1.0.0
 ---
 
 # Clean Architecture, Hexagonal Architecture & DDD for PHP/Symfony

--- a/plugins/developer-kit-php/skills/wordpress/wordpress-sage-theme/SKILL.md
+++ b/plugins/developer-kit-php/skills/wordpress/wordpress-sage-theme/SKILL.md
@@ -2,9 +2,6 @@
 name: wordpress-sage-theme
 description: 'Provides WordPress theme development patterns using Sage (roots/sage) framework. Use when creating, modifying, or debugging WordPress themes with Sage, including (1): creating new Sage themes from scratch, (2): setting up Blade templates and components, (3): configuring build tools (Vite, Bud), (4): working with WordPress theme templates and hierarchy, (5): implementing ACF fields integration, (6): theme customization and asset management.'
 allowed-tools: Read, Write, Bash, Glob, Grep
-category: frontend
-tags: [wordpress, sage, theme, blade, acf, bud, vite, php]
-version: 1.0.0
 ---
 
 # WordPress Sage Theme Development

--- a/plugins/developer-kit-python/skills/aws-lambda-python-integration/SKILL.md
+++ b/plugins/developer-kit-python/skills/aws-lambda-python-integration/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: aws-lambda-python-integration
 description: Provides AWS Lambda integration patterns for Python with cold start optimization. Use when deploying Python functions to AWS Lambda, choosing between AWS Chalice and raw Python approaches, optimizing cold starts, configuring API Gateway or ALB integration, or implementing serverless Python applications. Triggers include "create lambda python", "deploy python lambda", "chalice lambda aws", "python lambda cold start", "aws lambda python performance", "python serverless framework".
-category: backend
-tags: [aws, lambda, python, chalice, serverless, cold-start]
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 

--- a/plugins/developer-kit-python/skills/clean-architecture/SKILL.md
+++ b/plugins/developer-kit-python/skills/clean-architecture/SKILL.md
@@ -2,9 +2,6 @@
 name: clean-architecture
 description: Provides implementation patterns for Clean Architecture, Hexagonal Architecture (Ports & Adapters), and Domain-Driven Design in Python applications with FastAPI or Flask. Use when designing maintainable backends with separation of concerns, implementing repository patterns, creating entities/value objects/aggregates, or structuring domain logic independent of frameworks for testability.
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash
-category: backend
-tags: [clean-architecture, hexagonal-architecture, ddd, domain-driven-design, python, fastapi, flask, ports-adapters]
-version: 1.0.0
 ---
 
 # Clean Architecture, DDD & Hexagonal Architecture for Python

--- a/plugins/developer-kit-typescript/skills/aws-lambda-typescript-integration/SKILL.md
+++ b/plugins/developer-kit-typescript/skills/aws-lambda-typescript-integration/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: aws-lambda-typescript-integration
 description: Provides AWS Lambda integration patterns for TypeScript with cold start optimization. Use when deploying TypeScript functions to AWS Lambda, choosing between NestJS framework and raw TypeScript approaches, optimizing cold starts, configuring API Gateway or ALB integration, or implementing serverless TypeScript applications. Triggers include "create lambda typescript", "deploy typescript lambda", "nestjs lambda aws", "raw typescript lambda", "aws lambda typescript performance".
-category: backend
-tags: [aws, lambda, typescript, nestjs, serverless, cold-start]
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash
 ---
 

--- a/plugins/developer-kit-typescript/skills/better-auth/SKILL.md
+++ b/plugins/developer-kit-typescript/skills/better-auth/SKILL.md
@@ -2,8 +2,6 @@
 name: better-auth
 description: Provides Better Auth authentication integration patterns for NestJS backend and Next.js frontend with Drizzle ORM and PostgreSQL. Use when implementing authentication - Setting up Better Auth with NestJS backend, Integrating Next.js App Router frontend, Configuring Drizzle ORM schema with PostgreSQL, Implementing social login (GitHub, Google, etc.), Adding plugins (2FA, Organization, SSO, Magic Link, Passkey), Email/password authentication with session management, Creating protected routes and middleware
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash
-category: backend
-tags: [authentication, better-auth, nestjs, nextjs, drizzle, postgresql, oauth, sso, 2fa]
 ---
 
 # Better Auth Integration Guide

--- a/plugins/developer-kit-typescript/skills/clean-architecture/SKILL.md
+++ b/plugins/developer-kit-typescript/skills/clean-architecture/SKILL.md
@@ -2,9 +2,6 @@
 name: clean-architecture
 description: Provides implementation patterns for Clean Architecture, Domain-Driven Design (DDD), and Hexagonal Architecture (Ports & Adapters) in NestJS/TypeScript applications. Use when structuring complex backend systems, designing domain layers with entities/value objects/aggregates, implementing ports and adapters, creating use cases, or refactoring from anemic models to rich domain models with dependency inversion.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
-category: backend
-tags: [clean-architecture, hexagonal-architecture, ddd, domain-driven-design, nestjs, typescript, ports-adapters]
-version: 1.0.0
 ---
 
 # Clean Architecture, DDD & Hexagonal Architecture for NestJS

--- a/plugins/developer-kit-typescript/skills/drizzle-orm-patterns/SKILL.md
+++ b/plugins/developer-kit-typescript/skills/drizzle-orm-patterns/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: drizzle-orm-patterns
-version: 1.0.0
 description: Provides comprehensive Drizzle ORM patterns for schema definition, CRUD operations, relations, queries, transactions, and migrations. Proactively use for any Drizzle ORM development including defining database schemas, writing type-safe queries, implementing relations, managing transactions, and setting up migrations with Drizzle Kit. Supports PostgreSQL, MySQL, SQLite, MSSQL, and CockroachDB.
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
-tags: [drizzle, orm, database, postgresql, mysql, sqlite, typescript, migrations, schema, queries]
-category: backend
 ---
 
 # Drizzle ORM Patterns

--- a/plugins/developer-kit-typescript/skills/nextjs-app-router/SKILL.md
+++ b/plugins/developer-kit-typescript/skills/nextjs-app-router/SKILL.md
@@ -2,9 +2,6 @@
 name: nextjs-app-router
 description: Provides patterns and code examples for building Next.js 16+ applications with App Router architecture. Use when creating projects with App Router, implementing Server Components and Client Components ("use client"), creating Server Actions for forms, building Route Handlers (route.ts), configuring caching with "use cache" directive (cacheLife, cacheTag), setting up parallel routes (@slot) or intercepting routes, migrating to proxy.ts, or working with App Router file conventions (layout.tsx, page.tsx, loading.tsx, error.tsx).
 allowed-tools: Read, Write, Edit, Bash
-category: frontend
-tags: [nextjs, next.js, app-router, react, typescript, server-components, client-components, server-actions]
-version: 1.0.0
 ---
 
 # Next.js App Router (Next.js 16+)

--- a/plugins/developer-kit-typescript/skills/nextjs-deployment/SKILL.md
+++ b/plugins/developer-kit-typescript/skills/nextjs-deployment/SKILL.md
@@ -2,9 +2,6 @@
 name: nextjs-deployment
 description: Provides comprehensive patterns for deploying Next.js applications to production. Use when configuring Docker containers, setting up GitHub Actions CI/CD pipelines, managing environment variables, implementing preview deployments, or setting up monitoring and logging for Next.js applications. Covers standalone output, multi-stage Docker builds, health checks, OpenTelemetry instrumentation, and production best practices.
 allowed-tools: Read, Write, Edit, Bash
-category: frontend
-tags: [nextjs, next.js, deployment, docker, github-actions, ci-cd, production, environment-variables, monitoring, logging]
-version: 1.0.0
 ---
 
 # Next.js Deployment

--- a/plugins/developer-kit-typescript/skills/nx-monorepo/SKILL.md
+++ b/plugins/developer-kit-typescript/skills/nx-monorepo/SKILL.md
@@ -2,8 +2,6 @@
 name: nx-monorepo
 description: Provides comprehensive Nx monorepo management guidance for TypeScript/JavaScript projects. Use when creating Nx workspaces, generating apps/libraries/components, running affected commands, setting up CI/CD, configuring Module Federation, or implementing NestJS backends within Nx
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
-category: backend
-tags: [nx, monorepo, typescript, javascript, workspace, ci-cd]
 ---
 
 # Nx Monorepo

--- a/plugins/developer-kit-typescript/skills/react-patterns/SKILL.md
+++ b/plugins/developer-kit-typescript/skills/react-patterns/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: react-patterns
-version: 2.0.0
 description: Provides comprehensive React 19 patterns covering Server Components, Actions, use() hook, useOptimistic, useFormStatus, useFormState, React Compiler, concurrent features, Suspense, and modern TypeScript development. Proactively use for any React development, component architecture, state management, performance optimization, or when implementing React 19's latest features.
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
-tags: [react, react-19, typescript, javascript, jsx, tsx, hooks, server-components, actions, suspense, concurrent-rendering, react-compiler, use-optimistic, form-actions]
-category: frontend
 ---
 
 # React Development Patterns

--- a/plugins/developer-kit-typescript/skills/typescript-docs/SKILL.md
+++ b/plugins/developer-kit-typescript/skills/typescript-docs/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: typescript-docs
-version: 1.0.0
 description: Generates comprehensive TypeScript documentation using JSDoc, TypeDoc, and multi-layered documentation patterns for different audiences. Use when creating API documentation, architectural decision records (ADRs), code examples, and framework-specific patterns for NestJS, Express, React, Angular, and Vue.
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
-category: frontend
-tags: [typescript, documentation, jsdoc, typedoc, api-docs, adr, react, angular, vue, nestjs, express]
 ---
 
 # TypeScript Documentation Skill


### PR DESCRIPTION
## Summary
Implements #55: Remove invalid frontmatter fields (category, tags, version)

- Removed non-standard YAML frontmatter fields from 82 SKILL.md files across all plugins
- These fields were causing 240 validation warnings

## Changes
- Removed `category:` field from 82 skills
- Removed `tags:` field from 82 skills
- Removed `version:` field from 76 skills

## Test Plan
- Ran validation: `python3 .skills-validator-check/validators/cli.py --all`
- Validation passes with 0 unknown frontmatter field warnings
- 70 remaining warnings are about file size (not related to this fix)

Closes #55