### PR TITLE
fix(ci): disable Trust Hub security check returning HTTP 400

### DIFF
--- a/.github/workflows/plugin-validation.yml
+++ b/.github/workflows/plugin-validation.yml
@@ -36,24 +36,27 @@ jobs:
           echo "Running plugin validation for all components..."
           python .skills-validator-check/validators/cli.py --all
 
-  security-check-skills:
-    name: Security Check Affected Skills
-    runs-on: ubuntu-latest
-    needs: validate-plugins
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Run Gen Agent Trust Hub security check
-        env:
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_HEAD_REF: ${{ github.head_ref }}
-          GITHUB_BASE_REF: ${{ github.base_ref }}
-        run: python .skills-validator-check/validators/security_checker.py
+  # Disabled: Trust Hub API only accepts ClawHub URLs (clawhub.ai/clawhub.com),
+  # not raw GitHub content URLs. All requests return HTTP 400 "Invalid skill URL".
+  # See: https://github.com/giuseppe-trisciuoglio/developer-kit/issues/100
+  # security-check-skills:
+  #   name: Security Check Affected Skills
+  #   runs-on: ubuntu-latest
+  #   needs: validate-plugins
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+  #
+  #     - name: Set up Python
+  #       uses: actions/setup-python@v5
+  #       with:
+  #         python-version: '3.11'
+  #
+  #     - name: Run Gen Agent Trust Hub security check
+  #       env:
+  #         GITHUB_REPOSITORY: ${{ github.repository }}
+  #         GITHUB_HEAD_REF: ${{ github.head_ref }}
+  #         GITHUB_BASE_REF: ${{ github.base_ref }}
+  #       run: python .skills-validator-check/validators/security_checker.py


### PR DESCRIPTION
## Description

Disables the `security-check-skills` CI job that was failing with HTTP 400 errors from the Trust Hub API on every PR.

## Root Cause

The Trust Hub API at `https://ai.gendigital.com/api/scan/lookup` **only accepts ClawHub URLs** (`clawhub.ai` or `clawhub.com`). The frontend validation explicitly states: *"Only ClawHub URLs are accepted"*.

The `security_checker.py` was sending raw GitHub content URLs (`https://raw.githubusercontent.com/...`), which the API always rejects with `HTTP 400: Bad Request / Invalid skill URL`.

## Changes

- Commented out the `security-check-skills` job in `.github/workflows/plugin-validation.yml`
- Added comments explaining the reason and linking to this issue

## Related Issue

Closes #100

## Verification

- [x] Root cause confirmed by testing the Trust Hub API directly
- [x] Frontend validation schema confirms: "Only ClawHub URLs are accepted"
- [x] CI workflow still runs the `validate-plugins` job normally
- [x] No breaking changes