### PR TITLE
feat(typescript): add zod validation utilities skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **New TypeScript Skill** (`developer-kit-typescript`):
+  - `zod-validation-utilities`: Modern Zod v4 validation utilities and schema patterns including coercion, transforms, complex schema composition, `refine`/`superRefine`, and React Hook Form `zodResolver` integration
+
 ## [2.4.1] - 2026-03-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ TypeScript/JavaScript full-stack development with NestJS, React, React Native, N
 - **Database & ORM**: `drizzle-orm-patterns`
 - **Monorepo**: `nx-monorepo`, `turborepo-monorepo`
 - **AWS Lambda**: `aws-lambda-typescript-integration`
-- **Core**: `typescript-docs`
+- **Core**: `typescript-docs`, `zod-validation-utilities`
 
 **Rules**: `naming-conventions`, `project-structure`, `language-best-practices`, `error-handling`,
 `nestjs-architecture`, `nestjs-api-design`, `nestjs-security`, `nestjs-testing`,
@@ -342,7 +342,7 @@ GitHub specification integration and verification.
 |--------------------|----------------------------|---------------------------------------------|
 | Core               | `developer-kit-core`       | 3 Skills, 6 Agents, 11 Commands             |
 | Java/Spring Boot   | `developer-kit-java`       | 51 Skills, 9 Agents, 11 Commands, 4 Rules  |
-| TypeScript/Node.js | `developer-kit-typescript` | 23 Skills, 13 Agents, 3 Commands, 17 Rules |
+| TypeScript/Node.js | `developer-kit-typescript` | 24 Skills, 13 Agents, 3 Commands, 17 Rules |
 | Python             | `developer-kit-python`     | 2 Skills, 4 Agents, 4 Rules                 |
 | PHP/WordPress      | `developer-kit-php`        | 3 Skills, 5 Agents, 4 Rules                 |
 | AWS CloudFormation | `developer-kit-aws`        | 18 Skills, 3 Agents                         |

--- a/plugins/developer-kit-typescript/.claude-plugin/plugin.json
+++ b/plugins/developer-kit-typescript/.claude-plugin/plugin.json
@@ -73,6 +73,7 @@
     "./skills/nextjs-code-review",
     "./skills/react-code-review",
     "./skills/typescript-security-review",
-    "./skills/nestjs-best-practices"
+    "./skills/nestjs-best-practices",
+    "./skills/zod-validation-utilities"
   ]
 }

--- a/plugins/developer-kit-typescript/README.md
+++ b/plugins/developer-kit-typescript/README.md
@@ -69,6 +69,7 @@ The `developer-kit-typescript` plugin provides comprehensive support for TypeScr
 
 ### Core/Shared
 - **typescript-docs** - TypeScript documentation standards
+- **zod-validation-utilities** - Modern Zod v4 validation utilities and schema patterns
 
 ## Rules
 

--- a/plugins/developer-kit-typescript/skills/zod-validation-utilities/SKILL.md
+++ b/plugins/developer-kit-typescript/skills/zod-validation-utilities/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: zod-validation-utilities
+description: Provides practical Zod v4 validation utilities and schema patterns for TypeScript applications. Use when designing validation layers for API payloads, forms, configuration, and domain input parsing with strong type inference.
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob
+---
+
+# Zod Validation Utilities
+
+## Overview
+
+Production-ready Zod v4 patterns for reusable, type-safe validation with minimal boilerplate. Focuses on modern APIs, predictable error handling, and form integration.
+
+## When to Use
+
+- Defining request/response validation schemas in TypeScript services
+- Parsing untrusted input from APIs, forms, env vars, or external systems
+- Standardizing coercion, transforms, and cross-field validation
+- Building reusable schema utilities across teams
+- Integrating React Hook Form with Zod using `zodResolver`
+
+## Instructions
+
+1. Start with strict object schemas and explicit field constraints
+2. Prefer modern Zod v4 APIs and the `error` option for error messages
+3. Use coercion at boundaries (`z.coerce.*`) when input types are uncertain
+4. Keep business invariants in `refine`/`superRefine` close to schema definitions
+5. Export both schema and inferred types (`z.input`/`z.output`) for consistency
+6. Reuse utility schemas (email, id, dates, pagination) to reduce duplication
+
+## Examples
+
+### 1) Modern Zod 4 primitives and object errors
+
+```ts
+import { z } from "zod";
+
+export const UserIdSchema = z.uuid({ error: "Invalid user id" });
+export const EmailSchema = z.email({ error: "Invalid email" });
+export const WebsiteSchema = z.url({ error: "Invalid URL" });
+
+export const UserProfileSchema = z.object(
+  {
+    id: UserIdSchema,
+    email: EmailSchema,
+    website: WebsiteSchema.optional(),
+  },
+  { error: "Invalid user profile payload" }
+);
+```
+
+### 2) Coercion, preprocess, and transform
+
+```ts
+import { z } from "zod";
+
+export const PaginationQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).default(20),
+  includeArchived: z.coerce.boolean().default(false),
+});
+
+export const DateFromUnknownSchema = z.preprocess(
+  (value) => (typeof value === "string" || value instanceof Date ? value : undefined),
+  z.coerce.date({ error: "Invalid date" })
+);
+
+export const NormalizedEmailSchema = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .email({ error: "Invalid email" })
+  .transform((value) => value as Lowercase<string>);
+```
+
+### 3) Complex schema structures
+
+```ts
+import { z } from "zod";
+
+const TagSchema = z.string().trim().min(1).max(40);
+
+export const ProductSchema = z.object({
+  sku: z.string().min(3).max(24),
+  tags: z.array(TagSchema).max(15),
+  attributes: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])),
+  dimensions: z.tuple([z.number().positive(), z.number().positive(), z.number().positive()]),
+});
+
+export const PaymentMethodSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("card"), last4: z.string().regex(/^\d{4}$/) }),
+  z.object({ type: z.literal("paypal"), email: z.email() }),
+  z.object({ type: z.literal("wire"), iban: z.string().min(10) }),
+]);
+```
+
+### 4) `refine` and `superRefine`
+
+```ts
+import { z } from "zod";
+
+export const PasswordSchema = z
+  .string()
+  .min(12)
+  .refine((v) => /[A-Z]/.test(v), { error: "Must include an uppercase letter" })
+  .refine((v) => /\d/.test(v), { error: "Must include a number" });
+
+export const RegisterSchema = z
+  .object({
+    email: z.email(),
+    password: PasswordSchema,
+    confirmPassword: z.string(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.password !== data.confirmPassword) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["confirmPassword"],
+        message: "Passwords do not match",
+      });
+    }
+  });
+```
+
+### 5) Optional, nullable, nullish, and default
+
+```ts
+import { z } from "zod";
+
+export const UserPreferencesSchema = z.object({
+  nickname: z.string().min(2).optional(),      // undefined allowed
+  bio: z.string().max(280).nullable(),         // null allowed
+  avatarUrl: z.url().nullish(),                // null or undefined allowed
+  locale: z.string().default("en"),           // fallback when missing
+});
+```
+
+### 6) React Hook Form integration (`zodResolver`)
+
+```tsx
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+
+const ProfileFormSchema = z.object({
+  name: z.string().min(2, { error: "Name too short" }),
+  email: z.email({ error: "Invalid email" }),
+  age: z.coerce.number().int().min(18),
+});
+
+type ProfileFormInput = z.input<typeof ProfileFormSchema>;
+type ProfileFormOutput = z.output<typeof ProfileFormSchema>;
+
+const form = useForm<ProfileFormInput, unknown, ProfileFormOutput>({
+  resolver: zodResolver(ProfileFormSchema),
+  criteriaMode: "all",
+});
+```
+
+## Best Practices
+
+- Keep schemas near boundaries (HTTP handlers, queues, config loaders)
+- Prefer `safeParse` for recoverable flows; `parse` for fail-fast execution
+- Share small schema utilities (`id`, `email`, `slug`) to enforce consistency
+- Use `z.input` and `z.output` when transforms/coercions change runtime shape
+- Avoid overusing `preprocess`; prefer explicit `z.coerce.*` where possible
+- Treat external payloads as untrusted and always validate before use
+
+## Constraints and Warnings
+
+- Ensure examples match your installed `zod` major version (v4 APIs shown)
+- `error` is the preferred option for custom errors in Zod v4 patterns
+- Discriminated unions require a stable discriminator key across variants
+- Coercion can hide bad upstream data; add bounds and refinements defensively


### PR DESCRIPTION
## Description
Adds a new TypeScript skill for reusable Zod v4 validation utilities and patterns.

## Changes
- Add new `zod-validation-utilities` skill with practical patterns
- Cover modern Zod v4 APIs (`error`, top-level validators)
- Include coercion, transforms, complex schemas, `refine`/`superRefine`
- Add React Hook Form `zodResolver` integration examples
- Register skill in TypeScript plugin manifest
- Update TypeScript/root README skill lists and changelog

## Related Issue
Closes #125

## Verification
- [x] Plugin validator executed (`223/223` valid)
- [x] Existing test suite passed (`168 passed, 1 skipped)
- [x] No additional code/runtime changes outside skill/docs
