### PR TITLE
upgrade skill-review to skill-review-and-optimize

### DIFF
--- a/.github/workflows/skill-apply-optimize.yml
+++ b/.github/workflows/skill-apply-optimize.yml
@@ -1,0 +1,21 @@
+name: Apply Skill Optimization
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  apply:
+    if: >-
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/apply-optimize')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.issue.pull_request.head.ref }}
+      - uses: tesslio/skill-review-and-optimize@d81583861aaf29d1da7f10e6539efef4e27b0dd5
+        with:
+          mode: 'apply'

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,4 +1,4 @@
-name: Skill Review
+name: Skill Review & Optimize
 on:
   pull_request:
     paths: ['**/SKILL.md']
@@ -11,4 +11,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: tesslio/skill-review@14b47c8420ff9ac9a12c30ed4b89ce0e9d0355ae # main
+      - uses: tesslio/skill-review-and-optimize@d81583861aaf29d1da7f10e6539efef4e27b0dd5
+        with:
+          optimize: 'true'
+          tessl-token: ${{ secrets.TESSL_API_TOKEN }}


### PR DESCRIPTION
hey @giuseppe-trisciuoglio, you already have `tesslio/skill-review` running on develop - this upgrades it to `tesslio/skill-review-and-optimize`, which is a direct superset. same review scoring, plus an _optimize_ flow on top.

## what changes

**upgraded `skill-review.yml`:**
- replaces `tesslio/skill-review` with `tesslio/skill-review-and-optimize`
- same trigger, same permissions, same review behavior
- adds optimization suggestions in a collapsible PR comment
- uses the same `TESSL_API_TOKEN` secret you already have configured

**new `skill-apply-optimize.yml`:**
- triggered when someone comments `/apply-optimize` on a PR
- commits the suggested optimizations to the PR branch
- eyes emoji on acknowledgement, rocket on completion

## how it fits with your existing CI

| workflow | trigger | purpose |
|---|---|---|
| `plugin-validation.yml` | PR | validates plugin structure |
| `skill-review.yml` (upgraded) | PR | review + optimize suggestions |
| `skill-apply-optimize.yml` (new) | `/apply-optimize` comment | commits accepted optimizations |
| `publish-tiles.yml` | push to main | publishes to registry + quality gate |
| `security-scan.yml` | PR + push | MCP security analysis |

no overlap - review-and-optimize handles PR-time feedback, publish gates on merge. both new action refs are SHA-pinned.

this means that it gives you and your contributors an instant quality signal on every skill.md change, as well as concrete improvements when you need them.