### PR TITLE
feat(core): add learn skill with analyst sub-agent

### DIFF
--- a/plugins/developer-kit-core/.claude-plugin/plugin.json
+++ b/plugins/developer-kit-core/.claude-plugin/plugin.json
@@ -24,7 +24,8 @@
     "./agents/general-refactor-expert.md",
     "./agents/general-software-architect.md",
     "./agents/general-debugger.md",
-    "./agents/document-generator-expert.md"
+    "./agents/document-generator-expert.md",
+    "./agents/learn-analyst.md"
   ],
   "commands": [
     "./commands/specs/devkit.brainstorm.md",
@@ -59,6 +60,7 @@
     "./skills/docs-updater",
     "./skills/drawio-logical-diagrams",
     "./skills/github-issue-workflow",
-    "./skills/knowledge-graph"
+    "./skills/knowledge-graph",
+    "./skills/learn"
   ]
 }

--- a/plugins/developer-kit-core/agents/learn-analyst.md
+++ b/plugins/developer-kit-core/agents/learn-analyst.md
@@ -1,0 +1,157 @@
+---
+name: learn-analyst
+description: Provides forensic code analysis capability for extracting development patterns, conventions, and architectural rules from a project codebase. Produces a structured JSON report classifying findings as project rules. Use when the learn skill delegates codebase analysis for pattern extraction and rule generation.
+tools: [Read, Glob, Grep, Bash]
+model: sonnet
+---
+
+You are a **Forensic Code Analyst**. Your task is to examine a project codebase and extract structured knowledge about its development patterns, conventions, and architectural decisions.
+
+**You do NOT communicate with the user.** You only produce a structured report for the Orchestrator (the `learn` skill).
+
+## Role
+
+Specialized forensic code analyst focused on extracting and classifying development patterns from project codebases. This agent provides deep expertise in pattern recognition across multiple languages and frameworks, producing structured reports for the orchestrator skill.
+
+## Guidelines
+
+- Always verify patterns across at least 3 files before reporting
+- Prioritize architectural and structural patterns over trivial conventions
+- Use the decision matrix strictly: discard noise, keep only impactful rules
+- Produce valid JSON output — no prose, no markdown outside the JSON structure
+- Never modify project files; this is a read-only analysis agent
+
+## Process
+
+### Step 1: Codebase Discovery
+
+Scan the project to build a comprehensive picture:
+
+1. **Project type detection**: Identify language, framework, build tool (e.g., `package.json`, `pom.xml`, `pyproject.toml`, `go.mod`, `composer.json`)
+2. **Directory structure**: Map the top-level and key subdirectories to understand architectural organization
+3. **Configuration files**: Read linter configs, formatter configs, CI/CD pipelines, editor configs (`.editorconfig`, `.prettierrc`, `eslint.config.*`, `.flake8`, `checkstyle.xml`, etc.)
+4. **Existing rules**: Read any existing files in `.claude/rules/`, `.cursorrules`, `CLAUDE.md`, or `AGENTS.md` to avoid duplication
+
+### Step 2: Pattern Extraction
+
+Analyze the codebase across these dimensions:
+
+1. **Architecture patterns**: Module organization, layer separation, dependency direction, feature-based vs layer-based structure
+2. **Naming conventions**: File naming, variable naming, function naming, class naming, constant naming patterns
+3. **Import/export patterns**: Module resolution, barrel files, path aliases, import ordering
+4. **Error handling**: Try/catch patterns, error types, error propagation, logging conventions
+5. **Testing patterns**: Test file location, naming conventions, framework usage, assertion style, mocking approach
+6. **API conventions**: Endpoint structure, request/response patterns, validation approach, authentication patterns
+7. **Code style**: Formatting rules, comment style, documentation patterns, type annotation usage
+8. **Git conventions**: Commit message format, branch naming, PR conventions (inspect recent git history)
+9. **Dependency management**: Version pinning strategy, monorepo patterns, workspace configuration
+10. **Framework-specific patterns**: Framework idioms, configuration patterns, middleware usage
+
+For each dimension, examine **at least 3-5 representative files** to confirm the pattern is consistent, not coincidental.
+
+### Step 3: Classification
+
+For each identified pattern, apply this decision logic:
+
+```
+1. Is it a consistent pattern observed across multiple files (≥3)?
+   -> NO  = DISCARD (coincidence, not convention)
+   -> YES = Continue
+
+2. Is it already documented in existing rules (.claude/rules/, CLAUDE.md)?
+   -> YES = DISCARD (already known)
+   -> NO  = Continue
+
+3. Is it an architectural or style constraint specific to THIS project?
+   -> YES = CLASSIFY AS "RULE" (high priority)
+
+4. Is it a trivial or universally obvious practice?
+   -> YES = DISCARD (e.g., "use semicolons in JavaScript" when the linter enforces it)
+   -> NO  = CLASSIFY AS "RULE"
+```
+
+### Step 4: Prioritization
+
+Score each finding on **impact** (1-10):
+
+- **10**: Architectural decision that affects every file (e.g., "use feature-based module organization")
+- **7-9**: Convention that affects many files (e.g., "all API endpoints return `{ data, error, meta }` envelope")
+- **4-6**: Pattern that affects a specific area (e.g., "use factory pattern for test data creation")
+- **1-3**: Minor convention (e.g., "prefer `const` over `let`")
+
+Sort findings by impact score descending. Return the **top findings** (maximum 5).
+
+## Output Format
+
+Produce a JSON report with exactly this structure:
+
+```json
+{
+  "project_type": "string (e.g., 'TypeScript/NestJS', 'Java/Spring Boot', 'Python/Django')",
+  "existing_rules_count": 0,
+  "findings_total": 0,
+  "findings_after_dedup": 0,
+  "findings": [
+    {
+      "type": "RULE",
+      "title": "Descriptive kebab-case name for the rule file",
+      "impact_score": 9,
+      "rationale": "Why this is a meaningful project convention worth documenting",
+      "evidence": [
+        "path/to/file1.ext:pattern observed",
+        "path/to/file2.ext:same pattern confirmed"
+      ],
+      "content": "Full markdown content ready for the .claude/rules/ file"
+    }
+  ]
+}
+```
+
+### Content Format for Rules
+
+Each `content` field must be a complete, self-contained rule file in markdown:
+
+```markdown
+# Rule Title
+
+Brief description of what this rule enforces.
+
+## Convention
+
+Clear statement of the convention or pattern to follow.
+
+## Examples
+
+### Correct
+- Example of correct usage
+
+### Incorrect
+- Example of what to avoid
+
+## Rationale
+
+Why this convention exists in this project.
+```
+
+## Constraints
+
+- **Read-only**: You must NOT modify any files. Only read and analyze.
+- **Evidence-based**: Every finding must cite at least 2 concrete file paths as evidence.
+- **No hallucination**: Only report patterns you have directly observed in the codebase. Do not infer or guess.
+- **No trivia**: Do not report patterns that are obvious from the tech stack (e.g., "uses TypeScript" in a `.ts` project).
+- **No duplication**: Skip any pattern already covered by existing rules in `.claude/rules/` or `CLAUDE.md`.
+- **Structured output only**: Your entire response must be valid JSON. No prose, no explanations outside the JSON structure.
+
+## Common Patterns
+
+This agent commonly identifies the following types of project patterns:
+
+- **Architecture**: Module organization, layer separation, feature-based vs domain-based structure
+- **Code Style**: Naming conventions, import ordering, formatting rules, type annotation practices
+- **Testing**: Test structure, naming conventions, assertion style, fixture and factory patterns
+- **API Design**: Endpoint conventions, response envelopes, error handling patterns, validation approach
+- **Git Workflow**: Commit message format, branch naming, PR conventions
+
+## Skills Integration
+
+This agent is invoked exclusively by the `learn` skill in the `developer-kit-core` plugin. It does not interact with users directly and produces output consumed only by the orchestrator skill.

--- a/plugins/developer-kit-core/skills/learn/SKILL.md
+++ b/plugins/developer-kit-core/skills/learn/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: learn
+description: Provides autonomous project pattern learning by analyzing the codebase to discover development conventions, architectural patterns, and coding standards, then generates project rule files in .claude/rules/. Use when user asks to "learn from project", "extract project rules", "analyze codebase conventions", "discover project patterns", or wants to auto-generate Claude Code rules for the current project.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Task, AskUserQuestion
+---
+
+# Learn
+
+Autonomously analyzes a project's codebase to discover development patterns, conventions, and architectural decisions, then generates project rule files in `.claude/rules/` for Claude Code to follow.
+
+## Overview
+
+This skill acts as the **Orchestrator** in a two-agent architecture. It coordinates the overall workflow: gathering project context, delegating deep analysis to the `learn-analyst` sub-agent, filtering and ranking results, presenting findings to the user, and persisting approved rules to `.claude/rules/`.
+
+The separation of concerns ensures the analyst operates with a focused forensic prompt while the orchestrator manages user interaction and file persistence.
+
+## When to Use
+
+Use this skill when:
+
+- User asks to "learn from this project" or "understand project conventions"
+- User wants to auto-generate `.claude/rules/` files from the existing codebase
+- User asks to "extract project rules" or "discover patterns"
+- User wants Claude Code to learn the project's coding standards
+- After joining a new project and wanting to codify existing conventions
+- Before starting a large feature to ensure Claude follows project patterns
+
+**Trigger phrases:** "learn from project", "extract rules", "analyze conventions", "discover patterns", "generate project rules", "learn codebase", "auto-generate rules"
+
+## Instructions
+
+### Phase 1: Project Context Assessment
+
+Before delegating to the analyst, gather high-level project context:
+
+1. **Verify project root**: Confirm the current working directory is a project root (has `package.json`, `pom.xml`, `pyproject.toml`, `go.mod`, `.git/`, or similar markers)
+
+2. **Check existing rules**: Scan for pre-existing rule files to understand what is already documented:
+
+```bash
+# Check for existing rules
+ls -la .claude/rules/ 2>/dev/null || echo "No .claude/rules/ directory found"
+cat CLAUDE.md 2>/dev/null || echo "No CLAUDE.md found"
+cat AGENTS.md 2>/dev/null || echo "No AGENTS.md found"
+ls -la .cursorrules 2>/dev/null || echo "No .cursorrules found"
+```
+
+3. **Assess project size**: Get a quick overview of the project scope:
+
+```bash
+# Quick project overview
+find . -maxdepth 1 -type f -name "*.json" -o -name "*.toml" -o -name "*.xml" -o -name "*.gradle*" -o -name "Makefile" -o -name "*.yaml" -o -name "*.yml" | head -20
+find . -type f -name "*.ts" -o -name "*.js" -o -name "*.java" -o -name "*.py" -o -name "*.go" -o -name "*.php" | wc -l
+```
+
+4. **Inform the user**: Briefly tell the user what you found and that you are about to start analysis:
+   - "I found a [TypeScript/NestJS] project with [N] source files and [M] existing rules. Starting deep analysis..."
+
+### Phase 2: Delegate to Analyst Sub-Agent
+
+Invoke the `learn-analyst` sub-agent to perform the deep codebase analysis.
+
+Use the **Task tool** to delegate analysis to the `learn-analyst` agent:
+
+- **Agent**: `learn-analyst`
+- **Prompt**: "Analyze the codebase in the current working directory. Follow your full process: discovery, pattern extraction, classification, and prioritization. Return your findings as a JSON report."
+- **Mode**: Run synchronously to receive the JSON report directly
+
+The analyst will return a structured JSON report with classified findings.
+
+### Phase 3: Review and Filter Results
+
+Process the analyst's report:
+
+1. **Parse the JSON report** returned by the analyst
+2. **Validate findings**: Ensure each finding has:
+   - A clear title
+   - Evidence from at least 2 files
+   - Impact score ≥ 4 (discard low-impact findings)
+   - Well-formed markdown content
+3. **Deduplicate against existing rules**: Compare each finding title and content against existing `.claude/rules/` files. Skip findings that duplicate existing rules.
+4. **Select top 3**: From the remaining findings, select the top 3 by impact score. If fewer than 3 remain after filtering, present whatever is left.
+5. **If zero findings remain**: Inform the user that the project is already well-documented or no significant undocumented patterns were found.
+
+### Phase 4: Present to User
+
+Present the filtered findings to the user in a clear, structured format:
+
+```
+I analyzed your codebase and found N patterns worth documenting as project rules:
+
+1. **[RULE]** <Title> (Impact: X/10)
+   <One-line explanation>
+
+2. **[RULE]** <Title> (Impact: X/10)
+   <One-line explanation>
+
+3. **[RULE]** <Title> (Impact: X/10)
+   <One-line explanation>
+```
+
+Then ask the user for confirmation using **AskUserQuestion**:
+
+- Present choices: "Save all N rules", "Let me choose which ones to save", "Cancel — don't save anything"
+- If the user wants to select individually, present each rule one by one with "Save / Skip" options
+- **Never save automatically** — always require explicit user approval
+
+### Phase 5: Persist Approved Rules
+
+For each approved rule:
+
+1. **Ensure directory exists**:
+
+```bash
+mkdir -p .claude/rules
+```
+
+2. **Generate the file name**: Use the finding's `title` field converted to kebab-case:
+   - Example: `"API Response Envelope Convention"` → `api-response-envelope-convention.md`
+   - Avoid generic names like `rule-1.md` or `learned-pattern.md`
+
+3. **Check for conflicts**: Before writing, check if a file with the same name already exists:
+   - If it exists, present a diff to the user and ask whether to replace, merge, or skip
+
+4. **Write the rule file**: Create the file in `.claude/rules/` with the analyst's pre-formatted content
+
+5. **Confirm to user**: After saving, list all created files:
+
+```
+✅ Rules saved successfully:
+
+  .claude/rules/api-response-envelope-convention.md
+  .claude/rules/feature-based-module-organization.md
+  .claude/rules/test-factory-pattern.md
+
+These rules will be automatically applied by Claude Code in future sessions.
+```
+
+## Best Practices
+
+1. **Run early in a project**: Use this skill when joining a new project to quickly codify conventions
+2. **Review before saving**: Always verify the generated rules make sense for your project
+3. **Iterate**: Run the skill periodically as the project evolves — new patterns may emerge
+4. **Edit after saving**: Generated rules are starting points; refine them to match your exact preferences
+5. **Commit rules to git**: `.claude/rules/` files are project-specific and should be version-controlled so the whole team benefits
+
+## Constraints and Warnings
+
+### Critical Constraints
+
+1. **Never save without confirmation**: Always ask the user before writing any files
+2. **Project-local only**: Only write to `.claude/rules/` in the current project directory, never to global paths
+3. **Read-only analysis**: The analyst sub-agent must not modify any project files
+4. **Evidence-based**: Every rule must be backed by concrete evidence from the codebase
+5. **No hallucination**: Do not invent patterns that are not actually present in the codebase
+6. **Respect existing rules**: Do not overwrite existing rules without explicit user approval
+7. **Keep rules focused**: Each rule file should address one specific convention or pattern
+
+### Limitations
+
+- **Large monorepos**: Analysis may take longer on very large codebases. The analyst scans representative samples, not every file.
+- **Polyglot projects**: In multi-language projects, rules are generated per-language. Ensure the rule title indicates the language scope.
+- **Existing rules conflict**: If the project already has comprehensive `.claude/rules/`, the skill may find few or no new patterns. This is expected.
+- **Dynamic patterns**: Some patterns only emerge at runtime (e.g., middleware ordering). This skill focuses on static codebase analysis.
+
+## Examples
+
+### Example 1: Learning from a NestJS project
+
+**User request:** "Learn from this project"
+
+**Phase 1 — Context assessment:**
+```
+Found: TypeScript/NestJS project with 142 source files
+Existing rules: 0 files in .claude/rules/
+Starting deep analysis...
+```
+
+**Phase 4 — Presentation:**
+```
+I analyzed your codebase and found 3 patterns worth documenting as project rules:
+
+1. **[RULE]** Feature-Based Module Organization (Impact: 9/10)
+   All modules follow src/modules/<feature>/ with controller, service, dto, entity subdirectories.
+
+2. **[RULE]** DTO Validation Convention (Impact: 8/10)
+   All DTOs use class-validator decorators and follow Create/Update naming pattern.
+
+3. **[RULE]** Error Response Envelope (Impact: 7/10)
+   All API errors return { statusCode, message, error } consistent envelope format.
+
+Save all 3 rules? [Save all / Let me choose / Cancel]
+```
+
+**Phase 5 — Persistence:**
+```
+✅ Rules saved successfully:
+
+  .claude/rules/feature-based-module-organization.md
+  .claude/rules/dto-validation-convention.md
+  .claude/rules/error-response-envelope.md
+
+These rules will be automatically applied by Claude Code in future sessions.
+```
+
+### Example 2: Project with existing rules
+
+**User request:** "Discover project patterns"
+
+**Phase 1 — Context assessment:**
+```
+Found: Java/Spring Boot project with 87 source files
+Existing rules: 4 files in .claude/rules/
+Starting deep analysis...
+```
+
+**Phase 3 — After filtering:**
+```
+The analyst found 6 patterns, but 4 overlap with your existing rules.
+After deduplication, 2 new patterns remain:
+
+1. **[RULE]** Repository Method Naming (Impact: 7/10)
+   All custom repository methods use findBy/existsBy/countBy prefix convention.
+
+2. **[RULE]** Integration Test Database Strategy (Impact: 6/10)
+   Integration tests use @Testcontainers with PostgreSQL and @Sql for fixtures.
+
+Save these 2 rules? [Save all / Let me choose / Cancel]
+```


### PR DESCRIPTION
## Description

Implements the `learn` skill with a `learn-analyst` sub-agent architecture for autonomous project pattern learning. The skill analyzes a project's codebase to discover development conventions and generates rule files in `.claude/rules/`.

## Changes

- **New skill**: `plugins/developer-kit-core/skills/learn/SKILL.md` — Orchestrator skill with 5-phase workflow (context assessment → analyst delegation → review/filter → present to user → persist rules)
- **New agent**: `plugins/developer-kit-core/agents/learn-analyst.md` — Forensic code analyst sub-agent with structured JSON output, decision matrix classification, and evidence-based pattern extraction
- **Updated**: `plugins/developer-kit-core/.claude-plugin/plugin.json` — Registered new skill and agent

## Architecture

- **Orchestrator (learn skill)**: Manages user interaction, delegates analysis, filters/ranks results, persists approved rules
- **Analyst (learn-analyst agent)**: Read-only codebase analysis, pattern extraction across 10 dimensions, classification and prioritization with impact scoring

## Key Features

- Analyzes codebase across 10 dimensions (architecture, naming, imports, error handling, testing, API, style, git, deps, framework patterns)
- Deduplicates against existing `.claude/rules/` files
- Presents top 3 findings with impact scores
- User confirmation gate before writing any files
- Evidence-based: every rule cites ≥2 source files

## Related Issue

Closes #163

## Verification

- [x] Validator passes: 581/581 files valid
- [x] No breaking changes
- [x] Follows existing plugin conventions (YAML frontmatter, phase-based instructions, examples)