### PR TITLE
feat(typescript): add Claude Code hooks for DX enforcement

### DIFF
--- a/plugins/developer-kit-typescript/.claude-plugin/plugin.json
+++ b/plugins/developer-kit-typescript/.claude-plugin/plugin.json
@@ -78,5 +78,6 @@
     "./skills/zod-validation-utilities",
     "./skills/aws-cdk"
   ],
-  "lspServers": "./.lsp.json"
+  "lspServers": "./.lsp.json",
+  "hooks": "./hooks/hooks.json"
 }

--- a/plugins/developer-kit-typescript/docs/README.md
+++ b/plugins/developer-kit-typescript/docs/README.md
@@ -160,13 +160,72 @@ developer-kit-typescript/
 - Architecture review
 - Documentation generation
 
-### UI Frameworks
-- **shadcn-ui**: Modern React component library
-- **Tailwind CSS**: Utility-first CSS framework
-- Component composition patterns
-- Responsive design
+## Claude Code Hooks
+
+The TypeScript plugin ships with four Claude Code hooks that run automatically during development sessions. All hooks are written in pure Python 3 (no external dependencies) and follow the same exit-code contract as the core plugin.
+
+| Hook script | Event | Blocking? | Purpose |
+|---|---|---|---|
+| `ts-session-context.py` | `PreToolUse` (first call) | No | Injects git branch, commits, and TODO.md into context |
+| `ts-file-validator.py` | `PostToolUse` (Write) | **Yes** (exit 2) | Enforces kebab-case naming for `.ts`/`.tsx` files |
+| `ts-pattern-validator.py` | `PostToolUse` (Write) | No (advisory) | Warns on anti-patterns and missing NestJS decorators |
+| `ts-quality-gate.py` | `Stop` | **Yes** (exit 2) | Runs `tsc --noEmit` and `eslint` on modified files |
+
+### Exit Code Semantics
+
+| Code | Meaning | Behavior |
+|---|---|---|
+| `0` | Success | Proceed silently |
+| `1` | Warning / context | Show stdout to Claude; continue |
+| `2` | Error / violation | Show stderr to Claude; **block** until fixed |
+
+### Session Context (`ts-session-context.py`)
+
+Fires once per session (first `PreToolUse` event) and outputs:
+
+- Active git branch and last 5 commits
+- Uncommitted changes summary
+- Project name, version, and detected frameworks (NestJS, Next.js, React, Nx, etc.)
+- Contents of `TODO.md` if present
+
+### File Naming Validator (`ts-file-validator.py`)
+
+Fires after every `Write` call that produces a `.ts` or `.tsx` file. **Blocks** (exit 2) if the base filename is not `kebab-case`:
+
+```
+# ✅ Valid
+user-profile.service.ts
+auth-token.controller.ts
+create-user.dto.ts
+
+# ❌ Blocked — must be renamed
+UserProfile.service.ts   → user-profile.service.ts
+authToken.controller.ts  → auth-token.controller.ts
+```
+
+`index.ts`, declaration files (`.d.ts`), and files inside `node_modules`, `dist`, `build` etc. are exempt.
+
+### Architectural Pattern Validator (`ts-pattern-validator.py`)
+
+Fires after every `Write` call on a TypeScript file. Emits non-blocking advisories (exit 1) for:
+
+- **Missing NestJS decorators** — e.g., a `.controller.ts` without `@Controller`
+- **Anti-patterns**: `any`, `@ts-ignore`, `@ts-nocheck`, `require()`, `console.*` in production code
+- **Direct instantiation**: `new SomeService()` / `new SomeRepository()`
+- **Business logic in controllers**: direct ORM/DB access in `.controller.ts`
+
+### Quality Gate (`ts-quality-gate.py`)
+
+Fires on every `Stop` event. Runs against the TypeScript project in `CLAUDE_CWD`:
+
+1. `npx tsc --noEmit` — type-checks the whole project
+2. `npx eslint <modified-files>` — lints only the files modified in the current session
+3. `npx nx affected --target=lint` — for Nx monorepos
+
+Exits with code 2 (blocking) if type errors or lint errors are found, code 1 for warnings, code 0 on clean.
 
 ---
+
 
 ## See Also
 

--- a/plugins/developer-kit-typescript/hooks/hooks.json
+++ b/plugins/developer-kit-typescript/hooks/hooks.json
@@ -26,6 +26,22 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/ts-pattern-validator.py",
             "statusMessage": "Checking TypeScript architectural patterns..."
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/ts-rules-tracker.py",
+            "statusMessage": "Indexing project rules for written file..."
+          }
+        ]
+      }
+    ],
+    "Prompt": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/ts-rules-verifier.py",
+            "statusMessage": "Checking pending project-rules verifications..."
           }
         ]
       }

--- a/plugins/developer-kit-typescript/hooks/hooks.json
+++ b/plugins/developer-kit-typescript/hooks/hooks.json
@@ -1,0 +1,45 @@
+{
+  "description": "TypeScript Developer Kit hooks — enforce naming conventions, architectural patterns, quality gates, and session context for TypeScript/NestJS/Nx projects",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/ts-session-context.py",
+            "statusMessage": "Loading TypeScript project context..."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/ts-file-validator.py",
+            "statusMessage": "Validating TypeScript file naming..."
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/ts-pattern-validator.py",
+            "statusMessage": "Checking TypeScript architectural patterns..."
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/ts-quality-gate.py",
+            "statusMessage": "Running TypeScript quality checks (tsc + eslint)..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/developer-kit-typescript/hooks/hooks.json
+++ b/plugins/developer-kit-typescript/hooks/hooks.json
@@ -1,14 +1,26 @@
 {
   "description": "TypeScript Developer Kit hooks — enforce naming conventions, architectural patterns, quality gates, and session context for TypeScript/NestJS/Nx projects",
   "hooks": {
-    "PreToolUse": [
+    "SessionStart": [
       {
-        "matcher": ".*",
+        "matcher": "*",
         "hooks": [
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/ts-session-context.py",
             "statusMessage": "Loading TypeScript project context..."
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/ts-dev-server-guard.py",
+            "statusMessage": "Checking for dev server command..."
           }
         ]
       }
@@ -21,7 +33,12 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/ts-file-validator.py",
             "statusMessage": "Validating TypeScript file naming..."
-          },
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/ts-pattern-validator.py",
@@ -30,7 +47,13 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/ts-rules-tracker.py",
-            "statusMessage": "Indexing project rules for written file..."
+            "statusMessage": "Indexing project rules for modified file..."
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/ts-prettier-format.py",
+            "statusMessage": "Auto-formatting with Prettier...",
+            "async": true
           }
         ]
       }
@@ -52,10 +75,12 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/ts-quality-gate.py",
-            "statusMessage": "Running TypeScript quality checks (tsc + eslint)..."
+            "statusMessage": "Running TypeScript quality checks (tsc + eslint)...",
+            "async": true
           }
         ]
       }
     ]
   }
 }
+

--- a/plugins/developer-kit-typescript/hooks/ts-dev-server-guard.py
+++ b/plugins/developer-kit-typescript/hooks/ts-dev-server-guard.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""TypeScript Dev Server Guard Hook.
+
+Intercepts long-running dev server commands (npm run dev, nest start, etc.)
+and automatically wraps them in a named tmux session so they run detached,
+logs are preserved, and Claude Code is not blocked.
+
+Hook event: PreToolUse (Bash)
+Input:  JSON via stdin  { "tool_name": "Bash", "tool_input": { "command": "..." } }
+Output:
+  - Modified JSON (command wrapped in tmux)  → stdout + exit 0
+  - Advisory message                          → stdout + exit 1  (tmux not found)
+  - Pass-through                              → no output + exit 0  (not a dev server)
+
+Zero external dependencies — pure Python 3 standard library only.
+"""
+
+import json
+import os
+import re
+import shutil
+import sys
+from pathlib import Path
+
+# ─── Dev Server Command Detection ────────────────────────────────────────────
+
+_DEV_SERVER_RE = re.compile(
+    r"(?:^|&&|\||\s)"  # start, chain, or whitespace
+    r"\s*(?:"
+    r"npm\s+run\s+(?:dev|start|watch)"
+    r"|npm\s+start"
+    r"|pnpm\s+(?:run\s+)?(?:dev|start|watch)"
+    r"|yarn\s+(?:run\s+)?(?:dev|start|watch)"
+    r"|bun\s+run\s+(?:dev|start)"
+    r"|nest\s+start(?:\s+--watch)?"
+    r"|ts-node(?:-dev)?\s+src/main"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _in_tmux() -> bool:
+    """Return True if the current process is already running inside tmux."""
+    return bool(os.environ.get("TMUX", ""))
+
+
+def _tmux_available() -> bool:
+    """Return True if tmux is installed on this system."""
+    return shutil.which("tmux") is not None
+
+
+def _sanitize_session_name(name: str) -> str:
+    """Create a safe tmux session name from a directory name."""
+    sanitized = re.sub(r"[^a-zA-Z0-9_-]", "_", name)
+    return sanitized[:32] or "dev"
+
+
+def _escape_for_single_quotes(s: str) -> str:
+    """Escape a string for safe use inside single-quoted shell arguments."""
+    return s.replace("'", "'\\''")
+
+
+# ─── Entry Point ─────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    if data.get("tool_name") != "Bash":
+        sys.exit(0)
+
+    cmd: str = data.get("tool_input", {}).get("command", "")
+    if not cmd or not _DEV_SERVER_RE.search(cmd):
+        sys.exit(0)
+
+    # Already inside a tmux session — pass through unchanged
+    if _in_tmux():
+        sys.exit(0)
+
+    # Tmux not installed — show advisory so Claude can decide
+    if not _tmux_available():
+        print(
+            "⚠️  Dev server detected outside tmux. Logs may be lost when the session ends.\n"
+            "   To preserve logs, install tmux (brew install tmux / apt install tmux)\n"
+            "   then re-run the command. Proceeding without tmux."
+        )
+        sys.exit(1)
+
+    # ── Transform: wrap command in a named tmux session ────────────────────
+    cwd = os.environ.get("CLAUDE_CWD", os.getcwd())
+    session_name = _sanitize_session_name(Path(cwd).name)
+    escaped_cmd = _escape_for_single_quotes(cmd)
+
+    tmux_cmd = (
+        f'SESSION="{session_name}"; '
+        f"tmux kill-session -t \"$SESSION\" 2>/dev/null || true; "
+        f"tmux new-session -d -s \"$SESSION\" '{escaped_cmd}' && "
+        f"echo \"[Dev Server] Started in tmux session '{session_name}'. "
+        f"View logs: tmux attach -t {session_name} | "
+        f"tail: tmux capture-pane -t {session_name} -p -S -100\""
+    )
+
+    data["tool_input"]["command"] = tmux_cmd
+    print(json.dumps(data))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/developer-kit-typescript/hooks/ts-file-validator.py
+++ b/plugins/developer-kit-typescript/hooks/ts-file-validator.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""TypeScript File Structure Validator Hook.
+
+Validates file naming conventions (kebab-case) and NestJS module structure
+when Claude writes a TypeScript file.
+
+Hook event: PostToolUse (Write)
+Input:  JSON via stdin  { "tool_name": "Write", "tool_input": { "file_path": "...", "content": "..." } }
+Output: Exit 0 = valid | Exit 2 = block (stderr shown to Claude)
+
+Zero external dependencies — pure Python 3 standard library only.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Optional
+
+# ─── Naming Convention Configuration ──────────────────────────────────────────
+
+# Compound suffixes used in NestJS — order matters (longest first)
+NESTJS_SUFFIXES: tuple[str, ...] = (
+    ".controller.spec.ts",
+    ".service.spec.ts",
+    ".module.spec.ts",
+    ".controller.ts",
+    ".service.ts",
+    ".module.ts",
+    ".guard.ts",
+    ".interceptor.ts",
+    ".pipe.ts",
+    ".filter.ts",
+    ".decorator.ts",
+    ".middleware.ts",
+    ".resolver.ts",
+    ".gateway.ts",
+    ".repository.ts",
+    ".dto.ts",
+    ".entity.ts",
+    ".schema.ts",
+    ".interface.ts",
+    ".enum.ts",
+    ".constants.ts",
+    ".types.ts",
+    ".config.ts",
+    ".mock.ts",
+    ".fixture.ts",
+    ".spec.ts",
+    ".test.ts",
+    ".e2e-spec.ts",
+    ".d.ts",
+)
+
+# Directories that bypass all validation
+EXEMPT_DIRS: frozenset[str] = frozenset(
+    {
+        "node_modules",
+        ".git",
+        "dist",
+        "build",
+        ".next",
+        ".turbo",
+        "__tests__",
+        "test",
+        "tests",
+        "e2e",
+        "mocks",
+        "__mocks__",
+        "generated",
+        ".cache",
+    }
+)
+
+# Regex for valid kebab-case base names (lowercase letters, digits, hyphens)
+_KEBAB_RE = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$")
+
+# Regex for valid index files
+_INDEX_RE = re.compile(r"^index\.(ts|tsx|js|jsx)$")
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _to_kebab(name: str) -> str:
+    """Convert PascalCase / camelCase to kebab-case."""
+    s = re.sub(r"(.)([A-Z][a-z]+)", r"\1-\2", name)
+    return re.sub(r"([a-z0-9])([A-Z])", r"\1-\2", s).lower()
+
+
+def _split_name(filename: str) -> tuple[str, str]:
+    """Return (base, compound_suffix) for a filename.
+
+    Example: 'user-profile.controller.ts' → ('user-profile', '.controller.ts')
+    """
+    for suffix in NESTJS_SUFFIXES:
+        if filename.endswith(suffix):
+            return filename[: -len(suffix)], suffix
+    p = Path(filename)
+    return p.stem, p.suffix
+
+
+def _in_exempt_dir(path: Path) -> bool:
+    return any(part in EXEMPT_DIRS for part in path.parts[:-1])
+
+
+# ─── Validation ───────────────────────────────────────────────────────────────
+
+
+def _validate(file_path: str) -> Optional[str]:
+    """Return an error message string if the file violates naming rules, else None."""
+    path = Path(file_path)
+    filename = path.name
+
+    # Only validate TypeScript / TSX files
+    if not (file_path.endswith(".ts") or file_path.endswith(".tsx")):
+        return None
+
+    # Skip exempt directories
+    if _in_exempt_dir(path):
+        return None
+
+    # Allow index files without further checks
+    if _INDEX_RE.match(filename):
+        return None
+
+    base, suffix = _split_name(filename)
+
+    if not base:
+        return None
+
+    if not _KEBAB_RE.match(base):
+        suggested = _to_kebab(base)
+        return (
+            f"File naming violation: '{filename}'\n"
+            f"  Base name '{base}' must use kebab-case.\n"
+            f"  Rename to: '{suggested}{suffix}'\n"
+            f"  Examples: 'user-profile{suffix}', 'auth-token{suffix}'"
+        )
+
+    return None
+
+
+# ─── Entry Point ──────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    if data.get("tool_name") != "Write":
+        sys.exit(0)
+
+    file_path: str = data.get("tool_input", {}).get("file_path", "")
+    if not file_path:
+        sys.exit(0)
+
+    error = _validate(file_path)
+    if error:
+        print("TypeScript file structure violation:", file=sys.stderr)
+        print(f"  {error}", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("Correct the file name before proceeding.", file=sys.stderr)
+        sys.exit(2)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/developer-kit-typescript/hooks/ts-pattern-validator.py
+++ b/plugins/developer-kit-typescript/hooks/ts-pattern-validator.py
@@ -2,11 +2,11 @@
 """TypeScript Architectural Pattern Validator Hook.
 
 Detects common anti-patterns and NestJS architectural violations in TypeScript
-files written by Claude Code. Emits advisory warnings (non-blocking) so the
-developer can make an informed decision without halting the workflow.
+files written or edited by Claude Code. Emits advisory warnings (non-blocking)
+so the developer can make an informed decision without halting the workflow.
 
-Hook event: PostToolUse (Write)
-Input:  JSON via stdin  { "tool_name": "Write", "tool_input": { "file_path": "...", "content": "..." } }
+Hook event: PostToolUse (Write | Edit | MultiEdit)
+Input:  JSON via stdin with tool_name and tool_input
 Output: Exit 0 = no issues | Exit 1 = advisory warnings (stdout shown to Claude)
 
 Zero external dependencies — pure Python 3 standard library only.
@@ -167,18 +167,32 @@ def _check_controller_db_access(file_path: str, content: str) -> list[str]:
 # ─── Entry Point ─────────────────────────────────────────────────────────────
 
 
+def _extract_content(tool_name: str, tool_input: dict) -> str:
+    """Return the new content being written/edited, based on tool type."""
+    if tool_name == "Write":
+        return tool_input.get("content", "")
+    if tool_name == "Edit":
+        return tool_input.get("new_string", "")
+    if tool_name == "MultiEdit":
+        return "\n".join(
+            edit.get("new_string", "") for edit in tool_input.get("edits", [])
+        )
+    return ""
+
+
 def main() -> None:
     try:
         data = json.load(sys.stdin)
     except (json.JSONDecodeError, ValueError):
         sys.exit(0)
 
-    if data.get("tool_name") != "Write":
+    tool_name = data.get("tool_name", "")
+    if tool_name not in ("Write", "Edit", "MultiEdit"):
         sys.exit(0)
 
     tool_input = data.get("tool_input", {})
     file_path: str = tool_input.get("file_path", "")
-    content: str = tool_input.get("content", "")
+    content: str = _extract_content(tool_name, tool_input)
 
     if not file_path or not content:
         sys.exit(0)

--- a/plugins/developer-kit-typescript/hooks/ts-pattern-validator.py
+++ b/plugins/developer-kit-typescript/hooks/ts-pattern-validator.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""TypeScript Architectural Pattern Validator Hook.
+
+Detects common anti-patterns and NestJS architectural violations in TypeScript
+files written by Claude Code. Emits advisory warnings (non-blocking) so the
+developer can make an informed decision without halting the workflow.
+
+Hook event: PostToolUse (Write)
+Input:  JSON via stdin  { "tool_name": "Write", "tool_input": { "file_path": "...", "content": "..." } }
+Output: Exit 0 = no issues | Exit 1 = advisory warnings (stdout shown to Claude)
+
+Zero external dependencies — pure Python 3 standard library only.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+# ─── NestJS Component Patterns ────────────────────────────────────────────────
+
+# Maps NestJS compound file suffix → at least one of these strings must appear
+_NESTJS_DECORATOR_MAP: dict[str, list[str]] = {
+    ".controller.ts": ["@Controller"],
+    ".service.ts": ["@Injectable"],
+    ".module.ts": ["@Module"],
+    ".guard.ts": ["@Injectable", "CanActivate"],
+    ".interceptor.ts": ["@Injectable", "NestInterceptor"],
+    ".pipe.ts": ["@Injectable", "PipeTransform"],
+    ".filter.ts": ["@Catch", "ExceptionFilter"],
+    ".resolver.ts": ["@Resolver"],
+    ".gateway.ts": ["@WebSocketGateway"],
+}
+
+# ─── Anti-Pattern Rules ───────────────────────────────────────────────────────
+# Each entry: (regex_pattern, short_title, actionable_advice)
+# Patterns are matched against a comment/string-stripped version of the source.
+
+_ANTI_PATTERNS: list[tuple[str, str, str]] = [
+    (
+        r"\bany\b",
+        "Unsafe 'any' type",
+        "Replace 'any' with a specific type or 'unknown' to preserve type safety.",
+    ),
+    (
+        r"@ts-ignore",
+        "TypeScript suppression @ts-ignore",
+        "Fix the underlying type error instead of suppressing it.",
+    ),
+    (
+        r"@ts-nocheck",
+        "TypeScript suppression @ts-nocheck",
+        "Fix type errors in this file instead of disabling type checking.",
+    ),
+    (
+        r"\brequire\s*\(",
+        "CommonJS require()",
+        "Use ES module 'import' syntax. TypeScript projects should avoid require().",
+    ),
+    (
+        r"\bconsole\.(log|debug|info|warn|error)\s*\(",
+        "console.* in production code",
+        "Use a structured logger (e.g., NestJS Logger, Winston, Pino) instead of console.*.",
+    ),
+    (
+        r"new\s+[A-Z][a-zA-Z]+Service\s*\(",
+        "Direct service instantiation",
+        "Inject services via the constructor instead of instantiating them with 'new'.",
+    ),
+    (
+        r"new\s+[A-Z][a-zA-Z]+Repository\s*\(",
+        "Direct repository instantiation",
+        "Inject repositories via the constructor instead of 'new'.",
+    ),
+]
+
+# ─── Controller-Specific Checks ───────────────────────────────────────────────
+
+# Patterns that suggest direct data-access logic inside a controller
+_DB_PATTERNS: list[str] = [
+    r"\.(find|findOne|findAll|findById|save|create|update|delete|remove|upsert)\s*\(",
+    r"\bRepository\s*<",
+    r"\bEntityManager\b",
+    r"\bDataSource\b",
+    r"\bgetRepository\s*\(",
+    r"\bprisma\.",
+    r"\bknex\(",
+    r"\bdb\.(query|execute|run)\s*\(",
+]
+
+# ─── Skip Rules ───────────────────────────────────────────────────────────────
+
+_EXEMPT_SUFFIXES: tuple[str, ...] = (
+    ".spec.ts",
+    ".test.ts",
+    ".e2e-spec.ts",
+    ".d.ts",
+    ".mock.ts",
+    ".fixture.ts",
+    ".config.ts",
+    ".constants.ts",
+    ".seed.ts",
+)
+
+_EXEMPT_DIRS: frozenset[str] = frozenset(
+    {"node_modules", "dist", "build", ".next", ".turbo", "generated", "__mocks__"}
+)
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _strip_noise(src: str) -> str:
+    """Remove comments and string literals to reduce false positives."""
+    # Block comments
+    src = re.sub(r"/\*.*?\*/", " ", src, flags=re.DOTALL)
+    # Line comments
+    src = re.sub(r"//[^\n]*", " ", src)
+    # Template literals (basic)
+    src = re.sub(r"`[^`]*`", '""', src, flags=re.DOTALL)
+    # Double-quoted strings
+    src = re.sub(r'"[^"\\]*(?:\\.[^"\\]*)*"', '""', src)
+    # Single-quoted strings
+    src = re.sub(r"'[^'\\]*(?:\\.[^'\\]*)*'", "''", src)
+    return src
+
+
+def _check_nestjs_decorators(file_path: str, content: str) -> list[str]:
+    """Warn if a NestJS component file is missing its expected decorator."""
+    warnings: list[str] = []
+    for suffix, expected in _NESTJS_DECORATOR_MAP.items():
+        if not file_path.endswith(suffix):
+            continue
+        if not any(dec in content for dec in expected):
+            warnings.append(
+                f"Missing decorator: '{Path(file_path).name}' should contain "
+                f"{' or '.join(expected)}. "
+                f"Verify this is a complete NestJS {suffix.lstrip('.')} file."
+            )
+    return warnings
+
+
+def _check_anti_patterns(content: str) -> list[str]:
+    """Scan stripped source for common TypeScript anti-patterns."""
+    warnings: list[str] = []
+    clean = _strip_noise(content)
+    for pattern, title, advice in _ANTI_PATTERNS:
+        if re.search(pattern, clean):
+            warnings.append(f"{title}: {advice}")
+    return warnings
+
+
+def _check_controller_db_access(file_path: str, content: str) -> list[str]:
+    """Warn if a NestJS controller contains direct database access."""
+    if not file_path.endswith(".controller.ts"):
+        return []
+    clean = _strip_noise(content)
+    for pattern in _DB_PATTERNS:
+        if re.search(pattern, clean):
+            return [
+                "Business logic in controller: Direct database/ORM access detected. "
+                "Move data access to a service or repository and inject it into the controller."
+            ]
+    return []
+
+
+# ─── Entry Point ─────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    if data.get("tool_name") != "Write":
+        sys.exit(0)
+
+    tool_input = data.get("tool_input", {})
+    file_path: str = tool_input.get("file_path", "")
+    content: str = tool_input.get("content", "")
+
+    if not file_path or not content:
+        sys.exit(0)
+
+    # Only TypeScript / TSX files
+    if not (file_path.endswith(".ts") or file_path.endswith(".tsx")):
+        sys.exit(0)
+
+    # Skip exempt types and directories
+    if any(file_path.endswith(s) for s in _EXEMPT_SUFFIXES):
+        sys.exit(0)
+
+    path_obj = Path(file_path)
+    if any(part in _EXEMPT_DIRS for part in path_obj.parts):
+        sys.exit(0)
+
+    warnings: list[str] = []
+    warnings.extend(_check_nestjs_decorators(file_path, content))
+    warnings.extend(_check_anti_patterns(content))
+    warnings.extend(_check_controller_db_access(file_path, content))
+
+    if warnings:
+        print(f"TypeScript pattern advisory for '{path_obj.name}':")
+        for i, msg in enumerate(warnings, 1):
+            print(f"  {i}. {msg}")
+        sys.exit(1)  # Advisory only — does NOT block
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/developer-kit-typescript/hooks/ts-prettier-format.py
+++ b/plugins/developer-kit-typescript/hooks/ts-prettier-format.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""TypeScript Prettier Auto-Format Hook.
+
+Automatically runs Prettier on TypeScript/JavaScript files after Claude writes
+or edits them, keeping the codebase consistently formatted without requiring a
+manual format step.
+
+Hook event: PostToolUse (Write | Edit | MultiEdit)  [async]
+Input:  JSON via stdin with tool_name and tool_input
+Output:
+  - Exit 0 = file formatted silently (or prettier not found)
+  - Exit 1 = advisory note shown to Claude (formatted successfully)
+
+Zero external dependencies — pure Python 3 standard library only.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# ─── Target file extensions ───────────────────────────────────────────────────
+
+_FORMATTABLE: tuple[str, ...] = (".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs")
+
+# ─── Prettier config file names ───────────────────────────────────────────────
+
+_PRETTIER_CONFIGS: tuple[str, ...] = (
+    ".prettierrc",
+    ".prettierrc.json",
+    ".prettierrc.yaml",
+    ".prettierrc.yml",
+    ".prettierrc.js",
+    ".prettierrc.cjs",
+    ".prettierrc.mjs",
+    "prettier.config.js",
+    "prettier.config.cjs",
+    "prettier.config.mjs",
+    "prettier.config.ts",
+)
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _find_project_root(start: Path) -> Path:
+    """Walk up from start to find the nearest package.json (= project root)."""
+    current = start if start.is_dir() else start.parent
+    for _ in range(20):
+        if (current / "package.json").exists():
+            return current
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return start if start.is_dir() else start.parent
+
+
+def _has_prettier(root: Path) -> bool:
+    """Return True if the project has a Prettier config or lists prettier as a dependency."""
+    # Config file presence
+    for cfg in _PRETTIER_CONFIGS:
+        if (root / cfg).exists():
+            return True
+    # package.json "prettier" key or devDependency
+    pkg = root / "package.json"
+    if pkg.exists():
+        try:
+            import json as _json
+
+            data = _json.loads(pkg.read_text(encoding="utf-8"))
+            if "prettier" in data:
+                return True
+            deps = {**data.get("dependencies", {}), **data.get("devDependencies", {})}
+            if "prettier" in deps:
+                return True
+        except Exception:
+            pass
+    return False
+
+
+def _resolve_prettier(root: Path) -> list[str]:
+    """Return the command prefix to invoke prettier, preferring local bin."""
+    local = root / "node_modules" / ".bin" / "prettier"
+    if local.exists():
+        return [str(local)]
+    npx = shutil.which("npx")
+    if npx:
+        return [npx, "prettier"]
+    return []
+
+
+def _get_file_path(tool_name: str, tool_input: dict) -> str:
+    """Extract the target file path from any tool type."""
+    return tool_input.get("file_path", "")
+
+
+# ─── Entry Point ─────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    tool_name = data.get("tool_name", "")
+    if tool_name not in ("Write", "Edit", "MultiEdit"):
+        sys.exit(0)
+
+    file_path = _get_file_path(tool_name, data.get("tool_input", {}))
+    if not file_path:
+        sys.exit(0)
+
+    # Only format TS/JS files
+    if not any(file_path.endswith(ext) for ext in _FORMATTABLE):
+        sys.exit(0)
+
+    resolved = Path(file_path)
+    if not resolved.exists():
+        sys.exit(0)
+
+    cwd = Path(os.environ.get("CLAUDE_CWD", os.getcwd()))
+    root = _find_project_root(resolved)
+
+    if not _has_prettier(root):
+        sys.exit(0)
+
+    prettier_cmd = _resolve_prettier(root)
+    if not prettier_cmd:
+        sys.exit(0)
+
+    try:
+        subprocess.run(
+            [*prettier_cmd, "--write", str(resolved)],
+            capture_output=True,
+            text=True,
+            cwd=str(root),
+            timeout=15,
+        )
+        # Brief advisory so Claude knows the file was reformatted
+        rel = resolved.relative_to(cwd) if resolved.is_absolute() and resolved.is_relative_to(cwd) else resolved
+        print(f"[Prettier] Auto-formatted: {rel}")
+        sys.exit(1)  # Exit 1: show advisory to Claude
+    except (subprocess.TimeoutExpired, OSError):
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/developer-kit-typescript/hooks/ts-quality-gate.py
+++ b/plugins/developer-kit-typescript/hooks/ts-quality-gate.py
@@ -14,6 +14,7 @@ Zero external dependencies — pure Python 3 standard library only.
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -140,6 +141,26 @@ def _get_modified_ts_files(cwd: Path) -> list[str]:
         return []
 
 
+# ─── Tool Resolution ──────────────────────────────────────────────────────────
+
+
+def _resolve_bin(tool: str, cwd: Path) -> list[str]:
+    """Resolve a tool command, preferring local node_modules/.bin over npx.
+
+    Returns the command prefix to invoke the tool. Prefers the local binary to
+    avoid npx downloading packages implicitly (supply-chain risk).
+    """
+    local = cwd / "node_modules" / ".bin" / tool
+    if local.exists():
+        return [str(local)]
+    if shutil.which(tool):
+        return [tool]
+    npx = shutil.which("npx")
+    if npx:
+        return [npx, tool]
+    return []
+
+
 # ─── Tool Runners ─────────────────────────────────────────────────────────────
 
 
@@ -164,21 +185,30 @@ def _run(cmd: list[str], cwd: Path) -> tuple[bool, str]:
 def _run_tsc(cwd: Path) -> tuple[bool, str]:
     if not _find_tsconfig(cwd):
         return True, ""
-    return _run(["npx", "--yes", "tsc", "--noEmit", "--pretty", "false"], cwd)
+    cmd = _resolve_bin("tsc", cwd)
+    if not cmd:
+        return True, ""
+    return _run([*cmd, "--noEmit", "--pretty", "false"], cwd)
 
 
 def _run_eslint(files: list[str], cwd: Path) -> tuple[bool, str]:
     if not files or not _has_eslint(cwd):
         return True, ""
+    cmd = _resolve_bin("eslint", cwd)
+    if not cmd:
+        return True, ""
     return _run(
-        ["npx", "--yes", "eslint", "--max-warnings=0", "--format=compact", *files],
+        [*cmd, "--max-warnings=0", "--format=compact", *files],
         cwd,
     )
 
 
 def _run_nx_lint(cwd: Path) -> tuple[bool, str]:
+    cmd = _resolve_bin("nx", cwd)
+    if not cmd:
+        return True, ""
     return _run(
-        ["npx", "--yes", "nx", "affected", "--target=lint", "--parallel=3"],
+        [*cmd, "affected", "--target=lint", "--parallel=3"],
         cwd,
     )
 
@@ -186,8 +216,11 @@ def _run_nx_lint(cwd: Path) -> tuple[bool, str]:
 def _run_prettier(files: list[str], cwd: Path) -> tuple[bool, str]:
     if not files or not _has_prettier(cwd):
         return True, ""
+    cmd = _resolve_bin("prettier", cwd)
+    if not cmd:
+        return True, ""
     return _run(
-        ["npx", "--yes", "prettier", "--check", *files],
+        [*cmd, "--check", *files],
         cwd,
     )
 

--- a/plugins/developer-kit-typescript/hooks/ts-quality-gate.py
+++ b/plugins/developer-kit-typescript/hooks/ts-quality-gate.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """TypeScript Quality Gate Hook.
 
-Runs type checking (tsc) and linting (eslint) on recently modified TypeScript
-files at the end of a Claude Code session. Supports plain TypeScript projects
-as well as Nx monorepos.
+Runs type checking (tsc), linting (eslint), and format checking (prettier)
+on recently modified TypeScript files at the end of a Claude Code session.
+Supports plain TypeScript projects as well as Nx monorepos.
 
 Hook event: Stop
 Input:  JSON via stdin  { "stop_reason": "end_turn", ... }
@@ -76,6 +76,32 @@ def _has_eslint(cwd: Path) -> bool:
 
 def _is_nx(cwd: Path) -> bool:
     return (cwd / "nx.json").exists()
+
+
+def _has_prettier(cwd: Path) -> bool:
+    """Return True if a Prettier config file is present in cwd."""
+    config_names = (
+        ".prettierrc",
+        ".prettierrc.js",
+        ".prettierrc.cjs",
+        ".prettierrc.mjs",
+        ".prettierrc.json",
+        ".prettierrc.yaml",
+        ".prettierrc.yml",
+        "prettier.config.js",
+        "prettier.config.mjs",
+        "prettier.config.cjs",
+    )
+    if any((cwd / name).exists() for name in config_names):
+        return True
+    pkg = cwd / "package.json"
+    if pkg.exists():
+        try:
+            data = json.loads(pkg.read_text(encoding="utf-8"))
+            return "prettier" in data
+        except Exception:
+            pass
+    return False
 
 
 # ─── Modified File Detection ──────────────────────────────────────────────────
@@ -157,6 +183,15 @@ def _run_nx_lint(cwd: Path) -> tuple[bool, str]:
     )
 
 
+def _run_prettier(files: list[str], cwd: Path) -> tuple[bool, str]:
+    if not files or not _has_prettier(cwd):
+        return True, ""
+    return _run(
+        ["npx", "--yes", "prettier", "--check", *files],
+        cwd,
+    )
+
+
 # ─── Entry Point ─────────────────────────────────────────────────────────────
 
 
@@ -169,7 +204,7 @@ def main() -> None:
     cwd = Path(os.environ.get("CLAUDE_CWD", os.getcwd()))
 
     # Nothing to do if no TypeScript project detected
-    if not _find_tsconfig(cwd) and not _has_eslint(cwd):
+    if not _find_tsconfig(cwd) and not _has_eslint(cwd) and not _has_prettier(cwd):
         sys.exit(0)
 
     modified = _get_modified_ts_files(cwd)
@@ -194,6 +229,16 @@ def main() -> None:
         nx_ok, nx_out = _run_nx_lint(cwd)
         if not nx_ok and nx_out:
             warnings.append(f"Nx lint issues:\n{nx_out}")
+
+    # --- Prettier format check on modified files ---
+    if modified:
+        prettier_ok, prettier_out = _run_prettier(modified, cwd)
+        if not prettier_ok and prettier_out:
+            warnings.append(
+                f"Prettier formatting issues ({len(modified)} file(s) checked):\n"
+                f"{prettier_out}\n"
+                f"Run: npx prettier --write <file> to fix."
+            )
 
     # --- Report ---
     if errors:

--- a/plugins/developer-kit-typescript/hooks/ts-quality-gate.py
+++ b/plugins/developer-kit-typescript/hooks/ts-quality-gate.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""TypeScript Quality Gate Hook.
+
+Runs type checking (tsc) and linting (eslint) on recently modified TypeScript
+files at the end of a Claude Code session. Supports plain TypeScript projects
+as well as Nx monorepos.
+
+Hook event: Stop
+Input:  JSON via stdin  { "stop_reason": "end_turn", ... }
+Output: Exit 0 = pass | Exit 1 = warnings | Exit 2 = errors (stderr shown to Claude)
+
+Zero external dependencies — pure Python 3 standard library only.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+# ─── Configuration ────────────────────────────────────────────────────────────
+
+# Maximum number of modified files to check (guards against huge diffs)
+MAX_FILES = 30
+
+# Subprocess timeout in seconds for individual tool invocations
+TOOL_TIMEOUT = 90
+
+# Maximum output characters per tool to show Claude
+MAX_OUTPUT_CHARS = 2000
+
+# Directories excluded from file detection
+EXCLUDED_DIRS: frozenset[str] = frozenset(
+    {"node_modules", "dist", "build", ".next", ".turbo", ".cache", "generated"}
+)
+
+
+# ─── Project Detection ────────────────────────────────────────────────────────
+
+
+def _find_tsconfig(cwd: Path) -> Optional[Path]:
+    """Locate the nearest tsconfig.json walking up from cwd (max 3 levels)."""
+    for candidate in [cwd, *list(cwd.parents)[:3]]:
+        tsconfig = candidate / "tsconfig.json"
+        if tsconfig.exists():
+            return tsconfig
+    return None
+
+
+def _has_eslint(cwd: Path) -> bool:
+    """Return True if an ESLint config file is present in cwd."""
+    config_names = (
+        ".eslintrc",
+        ".eslintrc.js",
+        ".eslintrc.cjs",
+        ".eslintrc.mjs",
+        ".eslintrc.json",
+        ".eslintrc.yaml",
+        ".eslintrc.yml",
+        "eslint.config.js",
+        "eslint.config.mjs",
+        "eslint.config.cjs",
+    )
+    if any((cwd / name).exists() for name in config_names):
+        return True
+    pkg = cwd / "package.json"
+    if pkg.exists():
+        try:
+            data = json.loads(pkg.read_text(encoding="utf-8"))
+            return "eslintConfig" in data
+        except Exception:
+            pass
+    return False
+
+
+def _is_nx(cwd: Path) -> bool:
+    return (cwd / "nx.json").exists()
+
+
+# ─── Modified File Detection ──────────────────────────────────────────────────
+
+
+def _get_modified_ts_files(cwd: Path) -> list[str]:
+    """Return paths of modified/untracked TypeScript files relative to cwd."""
+    try:
+        staged = subprocess.run(
+            ["git", "diff", "--name-only", "--diff-filter=ACMR", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=str(cwd),
+            timeout=10,
+        )
+        untracked = subprocess.run(
+            ["git", "ls-files", "--others", "--exclude-standard"],
+            capture_output=True,
+            text=True,
+            cwd=str(cwd),
+            timeout=10,
+        )
+        all_files: list[str] = []
+        for line in (staged.stdout + "\n" + untracked.stdout).splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            if not (line.endswith(".ts") or line.endswith(".tsx")):
+                continue
+            if any(part in EXCLUDED_DIRS for part in Path(line).parts):
+                continue
+            if line not in all_files:
+                all_files.append(line)
+        return all_files[:MAX_FILES]
+    except Exception:
+        return []
+
+
+# ─── Tool Runners ─────────────────────────────────────────────────────────────
+
+
+def _run(cmd: list[str], cwd: Path) -> tuple[bool, str]:
+    """Run a subprocess and return (success, output)."""
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=str(cwd),
+            timeout=TOOL_TIMEOUT,
+        )
+        raw = (result.stdout + result.stderr).strip()
+        return result.returncode == 0, raw[:MAX_OUTPUT_CHARS]
+    except FileNotFoundError:
+        return True, ""  # Tool not installed — skip silently
+    except subprocess.TimeoutExpired:
+        return True, f"{cmd[0]} timed out after {TOOL_TIMEOUT}s (skipped)"
+
+
+def _run_tsc(cwd: Path) -> tuple[bool, str]:
+    if not _find_tsconfig(cwd):
+        return True, ""
+    return _run(["npx", "--yes", "tsc", "--noEmit", "--pretty", "false"], cwd)
+
+
+def _run_eslint(files: list[str], cwd: Path) -> tuple[bool, str]:
+    if not files or not _has_eslint(cwd):
+        return True, ""
+    return _run(
+        ["npx", "--yes", "eslint", "--max-warnings=0", "--format=compact", *files],
+        cwd,
+    )
+
+
+def _run_nx_lint(cwd: Path) -> tuple[bool, str]:
+    return _run(
+        ["npx", "--yes", "nx", "affected", "--target=lint", "--parallel=3"],
+        cwd,
+    )
+
+
+# ─── Entry Point ─────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    try:
+        json.load(sys.stdin)  # consume input even if unused
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    cwd = Path(os.environ.get("CLAUDE_CWD", os.getcwd()))
+
+    # Nothing to do if no TypeScript project detected
+    if not _find_tsconfig(cwd) and not _has_eslint(cwd):
+        sys.exit(0)
+
+    modified = _get_modified_ts_files(cwd)
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    # --- TypeScript type checking ---
+    tsc_ok, tsc_out = _run_tsc(cwd)
+    if not tsc_ok and tsc_out:
+        errors.append(f"TypeScript type errors:\n{tsc_out}")
+
+    # --- ESLint on modified files ---
+    if modified:
+        eslint_ok, eslint_out = _run_eslint(modified, cwd)
+        if not eslint_ok and eslint_out:
+            errors.append(
+                f"ESLint violations ({len(modified)} file(s) checked):\n{eslint_out}"
+            )
+
+    # --- Nx lint for affected projects ---
+    if _is_nx(cwd):
+        nx_ok, nx_out = _run_nx_lint(cwd)
+        if not nx_ok and nx_out:
+            warnings.append(f"Nx lint issues:\n{nx_out}")
+
+    # --- Report ---
+    if errors:
+        print("TypeScript Quality Gate — FAILED", file=sys.stderr)
+        for err in errors:
+            print(f"\n{err}", file=sys.stderr)
+        if modified:
+            print(f"\nFiles checked: {', '.join(modified)}", file=sys.stderr)
+        sys.exit(2)
+
+    if warnings:
+        print("TypeScript Quality Gate — WARNINGS")
+        for warn in warnings:
+            print(f"\n{warn}")
+        sys.exit(1)
+
+    if modified or _find_tsconfig(cwd):
+        print(
+            f"TypeScript Quality Gate — PASSED"
+            + (f" ({len(modified)} modified file(s) checked)" if modified else "")
+        )
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/developer-kit-typescript/hooks/ts-rules-tracker.py
+++ b/plugins/developer-kit-typescript/hooks/ts-rules-tracker.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""TypeScript Rules Tracker Hook.
+
+Fires after Claude writes a TypeScript file. Finds .claude/rules/ entries
+whose 'paths:' frontmatter matches the written file and persists them to a
+per-session state file so the Prompt hook can pick them up.
+
+Hook event: PostToolUse (Write)
+Input:  JSON via stdin  { "tool_name": "Write", "tool_input": { "file_path": "...", "content": "..." } }
+Output: always Exit 0 — side effect only (writes state file)
+
+Zero external dependencies — pure Python 3 standard library only.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+# Shared state file path — must match ts-rules-verifier.py
+_STATE_PREFIX = "/tmp/.ts-rules-pending-"
+
+TS_EXTENSIONS: tuple[str, ...] = (".ts", ".tsx", ".js", ".jsx")
+
+
+# ─── Minimal YAML Frontmatter Parser ─────────────────────────────────────────
+
+
+def _parse_frontmatter(text: str) -> tuple[dict, str]:
+    """Return (frontmatter_dict, body). Handles only the simple subset used in
+    .claude/rules files: top-level key:value pairs and list items (- value)."""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}, text
+
+    end: Optional[int] = None
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            end = i
+            break
+    if end is None:
+        return {}, text
+
+    fm: dict = {}
+    current_key: Optional[str] = None
+    for line in lines[1:end]:
+        stripped = line.strip()
+        if stripped.startswith("- "):
+            val = stripped[2:].strip().strip("\"'")
+            if current_key is not None and isinstance(fm.get(current_key), list):
+                fm[current_key].append(val)
+        elif ":" in stripped:
+            key, _, val = stripped.partition(":")
+            key, val = key.strip(), val.strip().strip("\"'")
+            if val:
+                fm[key] = val
+                current_key = None
+            else:
+                fm[key] = []
+                current_key = key
+
+    return fm, "\n".join(lines[end + 1 :]).strip()
+
+
+# ─── Path Matching ────────────────────────────────────────────────────────────
+
+
+def _matches_any(file_path: str, patterns: list[str]) -> bool:
+    p = Path(file_path)
+    rel = Path(p.as_posix().lstrip("/"))
+    return any(p.match(pat) or rel.match(pat) for pat in patterns)
+
+
+# ─── State File ───────────────────────────────────────────────────────────────
+
+
+def _session_key() -> str:
+    cwd = os.environ.get("CLAUDE_CWD", os.getcwd())
+    # Use a short hash of CLAUDE_CWD — stable across all hooks in the same session
+    import hashlib
+    return hashlib.md5(cwd.encode()).hexdigest()[:12]
+
+
+def _state_path() -> Path:
+    return Path(f"{_STATE_PREFIX}{_session_key()}.json")
+
+
+def _load_state() -> list[dict]:
+    sp = _state_path()
+    if sp.exists():
+        try:
+            return json.loads(sp.read_text(encoding="utf-8"))
+        except Exception:
+            pass
+    return []
+
+
+def _save_state(entries: list[dict]) -> None:
+    try:
+        _state_path().write_text(json.dumps(entries, indent=2), encoding="utf-8")
+    except OSError:
+        pass
+
+
+# ─── Entry Point ─────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    if data.get("tool_name") != "Write":
+        sys.exit(0)
+
+    file_path: str = data.get("tool_input", {}).get("file_path", "")
+    if not file_path or not any(file_path.endswith(ext) for ext in TS_EXTENSIONS):
+        sys.exit(0)
+
+    cwd = Path(os.environ.get("CLAUDE_CWD", os.getcwd()))
+    rules_dir = cwd / ".claude" / "rules"
+    if not rules_dir.is_dir():
+        sys.exit(0)
+
+    matched: list[dict] = []
+    for rule_file in sorted(rules_dir.glob("*.md")):
+        try:
+            raw = rule_file.read_text(encoding="utf-8")
+        except OSError:
+            continue
+
+        fm, body = _parse_frontmatter(raw)
+        paths = fm.get("paths", [])
+        if not paths:
+            continue
+        if isinstance(paths, str):
+            paths = [paths]
+        if not _matches_any(file_path, paths):
+            continue
+
+        # Extract H1 title from body
+        title = rule_file.stem.replace("-", " ").title()
+        for line in body.splitlines():
+            heading = line.lstrip("#").strip()
+            if heading:
+                title = heading
+                break
+
+        matched.append(
+            {
+                "file": rule_file.name,
+                "title": title,
+                "body": body[:2000],
+            }
+        )
+
+    if not matched:
+        sys.exit(0)
+
+    # Append to state (avoid duplicates for the same file)
+    state = _load_state()
+    existing_files = {e["written_file"] for e in state}
+    if file_path not in existing_files:
+        state.append({"written_file": file_path, "rules": matched})
+        _save_state(state)
+
+    sys.exit(0)  # Always non-blocking — Prompt hook does the actual verification
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/developer-kit-typescript/hooks/ts-rules-tracker.py
+++ b/plugins/developer-kit-typescript/hooks/ts-rules-tracker.py
@@ -12,14 +12,15 @@ Output: always Exit 0 — side effect only (writes state file)
 Zero external dependencies — pure Python 3 standard library only.
 """
 
+import hashlib
 import json
 import os
 import sys
 from pathlib import Path
 from typing import Optional
 
-# Shared state file path — must match ts-rules-verifier.py
-_STATE_PREFIX = "/tmp/.ts-rules-pending-"
+# State directory lives under $CLAUDE_CWD/.claude/ (project-local, not world-readable)
+_STATE_FILENAME_PREFIX = ".ts-rules-pending-"
 
 TS_EXTENSIONS: tuple[str, ...] = (".ts", ".tsx", ".js", ".jsx")
 
@@ -77,13 +78,14 @@ def _matches_any(file_path: str, patterns: list[str]) -> bool:
 
 def _session_key() -> str:
     cwd = os.environ.get("CLAUDE_CWD", os.getcwd())
-    # Use a short hash of CLAUDE_CWD — stable across all hooks in the same session
-    import hashlib
-    return hashlib.md5(cwd.encode()).hexdigest()[:12]
+    return hashlib.sha256(cwd.encode()).hexdigest()[:12]
 
 
 def _state_path() -> Path:
-    return Path(f"{_STATE_PREFIX}{_session_key()}.json")
+    cwd = Path(os.environ.get("CLAUDE_CWD", os.getcwd()))
+    state_dir = cwd / ".claude"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    return state_dir / f"{_STATE_FILENAME_PREFIX}{_session_key()}.json"
 
 
 def _load_state() -> list[dict]:
@@ -98,7 +100,9 @@ def _load_state() -> list[dict]:
 
 def _save_state(entries: list[dict]) -> None:
     try:
-        _state_path().write_text(json.dumps(entries, indent=2), encoding="utf-8")
+        sp = _state_path()
+        sp.write_text(json.dumps(entries, indent=2), encoding="utf-8")
+        os.chmod(sp, 0o600)
     except OSError:
         pass
 

--- a/plugins/developer-kit-typescript/hooks/ts-rules-tracker.py
+++ b/plugins/developer-kit-typescript/hooks/ts-rules-tracker.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """TypeScript Rules Tracker Hook.
 
-Fires after Claude writes a TypeScript file. Finds .claude/rules/ entries
-whose 'paths:' frontmatter matches the written file and persists them to a
-per-session state file so the Prompt hook can pick them up.
+Fires after Claude writes or edits a TypeScript file. Finds .claude/rules/
+entries whose 'paths:' frontmatter matches the modified file and persists them
+to a per-session state file so the Prompt hook can pick them up.
 
-Hook event: PostToolUse (Write)
-Input:  JSON via stdin  { "tool_name": "Write", "tool_input": { "file_path": "...", "content": "..." } }
+Hook event: PostToolUse (Write | Edit | MultiEdit)
+Input:  JSON via stdin with tool_name and tool_input
 Output: always Exit 0 — side effect only (writes state file)
 
 Zero external dependencies — pure Python 3 standard library only.
@@ -112,7 +112,7 @@ def main() -> None:
     except (json.JSONDecodeError, ValueError):
         sys.exit(0)
 
-    if data.get("tool_name") != "Write":
+    if data.get("tool_name") not in ("Write", "Edit", "MultiEdit"):
         sys.exit(0)
 
     file_path: str = data.get("tool_input", {}).get("file_path", "")

--- a/plugins/developer-kit-typescript/hooks/ts-rules-verifier.py
+++ b/plugins/developer-kit-typescript/hooks/ts-rules-verifier.py
@@ -13,6 +13,7 @@ Output: Exit 0 = nothing pending | Exit 1 = inject verification directive to Cla
 Zero external dependencies — pure Python 3 standard library only.
 """
 
+import hashlib
 import json
 import os
 import sys
@@ -20,7 +21,7 @@ from pathlib import Path
 from typing import Optional
 
 # Must match ts-rules-tracker.py
-_STATE_PREFIX = "/tmp/.ts-rules-pending-"
+_STATE_FILENAME_PREFIX = ".ts-rules-pending-"
 
 
 # ─── State File ───────────────────────────────────────────────────────────────
@@ -28,12 +29,14 @@ _STATE_PREFIX = "/tmp/.ts-rules-pending-"
 
 def _session_key() -> str:
     cwd = os.environ.get("CLAUDE_CWD", os.getcwd())
-    import hashlib
-    return hashlib.md5(cwd.encode()).hexdigest()[:12]
+    return hashlib.sha256(cwd.encode()).hexdigest()[:12]
 
 
 def _state_path() -> Path:
-    return Path(f"{_STATE_PREFIX}{_session_key()}.json")
+    cwd = Path(os.environ.get("CLAUDE_CWD", os.getcwd()))
+    state_dir = cwd / ".claude"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    return state_dir / f"{_STATE_FILENAME_PREFIX}{_session_key()}.json"
 
 
 def _consume_state() -> list[dict]:

--- a/plugins/developer-kit-typescript/hooks/ts-rules-verifier.py
+++ b/plugins/developer-kit-typescript/hooks/ts-rules-verifier.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""TypeScript Rules Verifier Hook.
+
+Fires before Claude generates its next response. Reads the pending-verification
+state written by ts-rules-tracker.py and injects an explicit verification
+directive so Claude actively checks each written file against the matching
+project rules — and fixes any violations before continuing.
+
+Hook event: Prompt
+Input:  JSON via stdin  { "prompt": "...", ... }
+Output: Exit 0 = nothing pending | Exit 1 = inject verification directive to Claude
+
+Zero external dependencies — pure Python 3 standard library only.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+# Must match ts-rules-tracker.py
+_STATE_PREFIX = "/tmp/.ts-rules-pending-"
+
+
+# ─── State File ───────────────────────────────────────────────────────────────
+
+
+def _session_key() -> str:
+    cwd = os.environ.get("CLAUDE_CWD", os.getcwd())
+    import hashlib
+    return hashlib.md5(cwd.encode()).hexdigest()[:12]
+
+
+def _state_path() -> Path:
+    return Path(f"{_STATE_PREFIX}{_session_key()}.json")
+
+
+def _consume_state() -> list[dict]:
+    """Read and delete the pending-verification state."""
+    sp = _state_path()
+    if not sp.exists():
+        return []
+    try:
+        entries = json.loads(sp.read_text(encoding="utf-8"))
+        sp.unlink(missing_ok=True)
+        return entries
+    except Exception:
+        return []
+
+
+# ─── Prompt Builder ───────────────────────────────────────────────────────────
+
+
+def _build_directive(entries: list[dict]) -> str:
+    """Build the verification directive injected into Claude's context."""
+    lines: list[str] = [
+        "## Project Rules Verification — Action Required",
+        "",
+        "You have written the following TypeScript file(s) this session.",
+        "Before responding to the user, **verify each file against its matching",
+        "project rules** (listed below). If any violation is found, **fix the file",
+        "immediately** using the Write tool, then confirm what was corrected.",
+        "",
+    ]
+
+    for entry in entries:
+        written = entry.get("written_file", "")
+        rules: list[dict] = entry.get("rules", [])
+        lines.append(f"### File: `{Path(written).name}` (`{written}`)")
+        lines.append("")
+        for rule in rules:
+            lines.append(f"#### Rule: {rule.get('title', rule.get('file', ''))}")
+            lines.append(rule.get("body", ""))
+            lines.append("")
+
+    lines += [
+        "---",
+        "After verifying (and fixing if needed), continue with the user's request.",
+    ]
+
+    return "\n".join(lines)
+
+
+# ─── Entry Point ─────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    try:
+        json.load(sys.stdin)  # consume input
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    entries = _consume_state()
+    if not entries:
+        sys.exit(0)
+
+    directive = _build_directive(entries)
+    print(directive)
+    sys.exit(1)  # Exit 1: inject directive into Claude's next prompt turn
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/developer-kit-typescript/hooks/ts-session-context.py
+++ b/plugins/developer-kit-typescript/hooks/ts-session-context.py
@@ -4,8 +4,8 @@
 Injects project context (git branch, recent commits, pending TODOs) into
 Claude's context window at the start of each development session.
 
-Hook event: PreToolUse (any tool, first invocation only per session)
-Input:  JSON via stdin  { "tool_name": "...", "tool_input": {...} }
+Hook event: SessionStart
+Input:  JSON via stdin  { "session_id": "...", "transcript_path": "..." }
 Output: Exit 0 = silent proceed | Exit 1 = inject context message to Claude
 
 Zero external dependencies — pure Python 3 standard library only.
@@ -18,9 +18,6 @@ import sys
 from pathlib import Path
 
 # ─── Configuration ────────────────────────────────────────────────────────────
-
-# Temporary marker file prefix — keyed by process group to scope to session
-_MARKER_PREFIX = "/tmp/.ts-session-ctx-"
 
 # Maximum characters for TODO.md content to avoid flooding the context
 _TODO_MAX_CHARS = 600
@@ -44,29 +41,6 @@ _FRAMEWORK_DEPS: list[tuple[str, str]] = [
     ("express", "Express"),
     ("hono", "Hono"),
 ]
-
-
-# ─── Session Marker ───────────────────────────────────────────────────────────
-
-
-def _session_key() -> str:
-    """Return a stable per-session identifier (process group ID)."""
-    try:
-        return str(os.getpgrp())
-    except AttributeError:
-        return str(os.getpid())
-
-
-def _is_first_call() -> bool:
-    """Return True (and create the marker) if this is the first hook call in the session."""
-    marker = Path(f"{_MARKER_PREFIX}{_session_key()}")
-    if marker.exists():
-        return False
-    try:
-        marker.touch()
-    except OSError:
-        pass
-    return True
 
 
 # ─── Context Collectors ───────────────────────────────────────────────────────
@@ -158,12 +132,9 @@ def _todo_section(cwd: str) -> str:
 
 def main() -> None:
     try:
-        json.load(sys.stdin)  # consume input
-    except (json.JSONDecodeError, ValueError):
+        sys.stdin.read()  # consume input (SessionStart sends minimal JSON)
+    except Exception:
         pass
-
-    if not _is_first_call():
-        sys.exit(0)
 
     cwd = os.environ.get("CLAUDE_CWD", os.getcwd())
 

--- a/plugins/developer-kit-typescript/hooks/ts-session-context.py
+++ b/plugins/developer-kit-typescript/hooks/ts-session-context.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""TypeScript Session Context Hook.
+
+Injects project context (git branch, recent commits, pending TODOs) into
+Claude's context window at the start of each development session.
+
+Hook event: PreToolUse (any tool, first invocation only per session)
+Input:  JSON via stdin  { "tool_name": "...", "tool_input": {...} }
+Output: Exit 0 = silent proceed | Exit 1 = inject context message to Claude
+
+Zero external dependencies — pure Python 3 standard library only.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# ─── Configuration ────────────────────────────────────────────────────────────
+
+# Temporary marker file prefix — keyed by process group to scope to session
+_MARKER_PREFIX = "/tmp/.ts-session-ctx-"
+
+# Maximum characters for TODO.md content to avoid flooding the context
+_TODO_MAX_CHARS = 600
+
+# Maximum number of recent commits to show
+_COMMIT_COUNT = 5
+
+# Known TypeScript/JavaScript framework dependencies to detect
+_FRAMEWORK_DEPS: list[tuple[str, str]] = [
+    ("@nestjs/core", "NestJS"),
+    ("next", "Next.js"),
+    ("react", "React"),
+    ("expo", "Expo / React Native"),
+    ("turbo", "Turborepo"),
+    ("nx", "Nx monorepo"),
+    ("@nrwl/workspace", "Nx monorepo"),
+    ("@angular/core", "Angular"),
+    ("vue", "Vue"),
+    ("svelte", "Svelte"),
+    ("fastify", "Fastify"),
+    ("express", "Express"),
+    ("hono", "Hono"),
+]
+
+
+# ─── Session Marker ───────────────────────────────────────────────────────────
+
+
+def _session_key() -> str:
+    """Return a stable per-session identifier (process group ID)."""
+    try:
+        return str(os.getpgrp())
+    except AttributeError:
+        return str(os.getpid())
+
+
+def _is_first_call() -> bool:
+    """Return True (and create the marker) if this is the first hook call in the session."""
+    marker = Path(f"{_MARKER_PREFIX}{_session_key()}")
+    if marker.exists():
+        return False
+    try:
+        marker.touch()
+    except OSError:
+        pass
+    return True
+
+
+# ─── Context Collectors ───────────────────────────────────────────────────────
+
+
+def _run_git(args: list[str], cwd: str) -> str:
+    """Run a git command and return stdout, or empty string on failure."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            timeout=5,
+        )
+        return result.stdout.strip()
+    except Exception:
+        return ""
+
+
+def _git_section(cwd: str) -> str:
+    """Build a Git context block (branch, recent commits, working tree status)."""
+    parts: list[str] = []
+
+    branch = _run_git(["branch", "--show-current"], cwd)
+    if branch:
+        parts.append(f"Branch: {branch}")
+
+    commits = _run_git(["log", "--oneline", f"-{_COMMIT_COUNT}"], cwd)
+    if commits:
+        indented = "\n  ".join(commits.splitlines())
+        parts.append(f"Recent commits:\n  {indented}")
+
+    status = _run_git(["status", "--short"], cwd)
+    if status:
+        indented = "\n  ".join(status.splitlines())
+        parts.append(f"Uncommitted changes:\n  {indented}")
+
+    return "\n".join(parts) if parts else ""
+
+
+def _project_section(cwd: str) -> str:
+    """Detect TypeScript project metadata from package.json."""
+    pkg_path = Path(cwd) / "package.json"
+    if not pkg_path.exists():
+        return ""
+    try:
+        data = json.loads(pkg_path.read_text(encoding="utf-8"))
+    except Exception:
+        return ""
+
+    all_deps = {**data.get("dependencies", {}), **data.get("devDependencies", {})}
+    frameworks = [label for dep, label in _FRAMEWORK_DEPS if dep in all_deps]
+
+    name = data.get("name", "")
+    version = data.get("version", "")
+    stack = ", ".join(frameworks) if frameworks else "TypeScript"
+
+    parts: list[str] = []
+    if name:
+        parts.append(f"Project: {name}" + (f" v{version}" if version else ""))
+    parts.append(f"Stack: {stack}")
+
+    node_version = data.get("engines", {}).get("node", "")
+    if node_version:
+        parts.append(f"Node engine: {node_version}")
+
+    return "\n".join(parts) if parts else ""
+
+
+def _todo_section(cwd: str) -> str:
+    """Read TODO.md (or TODO) if present."""
+    for name in ("TODO.md", "todo.md", "TODO"):
+        path = Path(cwd) / name
+        if path.exists():
+            try:
+                content = path.read_text(encoding="utf-8").strip()
+                if content:
+                    truncated = content[:_TODO_MAX_CHARS]
+                    suffix = "..." if len(content) > _TODO_MAX_CHARS else ""
+                    return f"{name}:\n{truncated}{suffix}"
+            except OSError:
+                pass
+    return ""
+
+
+# ─── Entry Point ─────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    try:
+        json.load(sys.stdin)  # consume input
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    if not _is_first_call():
+        sys.exit(0)
+
+    cwd = os.environ.get("CLAUDE_CWD", os.getcwd())
+
+    sections: list[str] = []
+
+    project = _project_section(cwd)
+    if project:
+        sections.append(project)
+
+    git = _git_section(cwd)
+    if git:
+        sections.append(git)
+
+    todos = _todo_section(cwd)
+    if todos:
+        sections.append(todos)
+
+    if not sections:
+        sys.exit(0)
+
+    header = "=== TypeScript Project Context ==="
+    body = "\n\n".join(sections)
+    print(f"{header}\n{body}")
+
+    sys.exit(1)  # Exit 1: show context to Claude without blocking the tool
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

Implements Claude Code Hooks for the `developer-kit-typescript` plugin (issue #177). Four Python hooks enforce naming conventions, architectural patterns, type safety, and session context injection across all TypeScript projects.

## Changes

- **`ts-file-validator.py`** (`PostToolUse/Write`, exit 2 blocking): enforces kebab-case naming for all `.ts`/`.tsx` files
- **`ts-pattern-validator.py`** (`PostToolUse/Write`, exit 1 advisory): warns on anti-patterns (any, @ts-ignore, console.*, direct instantiation) and missing NestJS decorators
- **`ts-quality-gate.py`** (`Stop`, exit 2 blocking): runs `tsc --noEmit` and `eslint` on modified files; supports Nx monorepo via `nx affected --target=lint`
- **`ts-session-context.py`** (`PreToolUse`, first call only): injects git branch, recent commits, uncommitted changes, and TODO.md into Claude's context
- **`hooks.json`**: manifest wiring all 4 hooks to their events
- **`plugin.json`**: registers `./hooks/hooks.json` in the plugin manifest
- **`docs/README.md`**: documents all hooks with exit code table and usage examples

## Related Issue

Closes #177

## Verification

- [x] All 4 Python scripts pass `python3 -m py_compile`
- [x] Both JSON files are valid
- [x] Smoke tests pass (blocking on PascalCase, advisory on console.log, context injection on first call)
- [x] Full validator suite passes: 605/605 valid (0 new warnings)
- [x] Pure Python 3 stdlib only — no external dependencies