### PR TITLE
security(typescript): remove phantom package reference in dependency security guide

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-kit",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Modular marketplace for developer kit plugins",
   "owner": {
     "name": "Giuseppe Trisciuoglio",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [3.0.1] - 2026-06-05
+
+### Security
+
+- Removed phantom package reference in TypeScript dependency security guide (`developer-kit-typescript`)
+  - Replaced unclaimed `@my-org/internal-lib` example with real, claimed scope (`@microsoft`) and explicit example disclaimer
+  - Added guidance to never reference unclaimed package names in documentation or install commands
+  - Reported by Noam at Blue Bear Security
+
 ## [3.0.0] - 2026-05-18
 
 ### Added

--- a/plugins/developer-kit-ai/.claude-plugin/plugin.json
+++ b/plugins/developer-kit-ai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-kit-ai",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "AI/ML capabilities including prompt engineering, RAG, and chunking strategies",
   "author": {
     "name": "Giuseppe Trisciuoglio",

--- a/plugins/developer-kit-aws/.claude-plugin/plugin.json
+++ b/plugins/developer-kit-aws/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-kit-aws",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "AWS infrastructure and CloudFormation expertise",
   "author": {
     "name": "Giuseppe Trisciuoglio",

--- a/plugins/developer-kit-core/.claude-plugin/plugin.json
+++ b/plugins/developer-kit-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-kit",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Core agents and commands required by all Developer Kit plugins",
   "author": {
     "name": "Giuseppe Trisciuoglio",

--- a/plugins/developer-kit-devops/.claude-plugin/plugin.json
+++ b/plugins/developer-kit-devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-kit-devops",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "DevOps and containerization expertise",
   "author": {
     "name": "Giuseppe Trisciuoglio",

--- a/plugins/developer-kit-java/.claude-plugin/plugin.json
+++ b/plugins/developer-kit-java/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-kit-java",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Comprehensive Java development toolkit with Spring Boot, testing, LangChain4J, and AWS integration",
   "author": {
     "name": "Giuseppe Trisciuoglio",

--- a/plugins/developer-kit-php/.claude-plugin/plugin.json
+++ b/plugins/developer-kit-php/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-kit-php",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "PHP and WordPress development capabilities",
   "author": {
     "name": "Giuseppe Trisciuoglio",

--- a/plugins/developer-kit-project-management/.claude-plugin/plugin.json
+++ b/plugins/developer-kit-project-management/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-kit-project-management",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Project management and workflow commands",
   "author": {
     "name": "Giuseppe Trisciuoglio",

--- a/plugins/developer-kit-python/.claude-plugin/plugin.json
+++ b/plugins/developer-kit-python/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-kit-python",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Python development capabilities",
   "author": {
     "name": "Giuseppe Trisciuoglio",

--- a/plugins/developer-kit-specs/.claude-plugin/plugin.json
+++ b/plugins/developer-kit-specs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-kit-specs",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Specifications-driven development workflow for transforming ideas into functional specifications and executable tasks",
   "author": {
     "name": "Giuseppe Trisciuoglio",

--- a/plugins/developer-kit-tools/.claude-plugin/plugin.json
+++ b/plugins/developer-kit-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-kit-tools",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "External tools integration skills for CLI utilities, APIs, and third-party services",
   "author": {
     "name": "Giuseppe Trisciuoglio",

--- a/plugins/developer-kit-typescript/.claude-plugin/plugin.json
+++ b/plugins/developer-kit-typescript/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-kit-typescript",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "TypeScript/JavaScript full-stack development with NestJS, React, and React Native",
   "author": {
     "name": "Giuseppe Trisciuoglio",

--- a/plugins/developer-kit-typescript/skills/typescript-security-review/references/dependency-security.md
+++ b/plugins/developer-kit-typescript/skills/typescript-security-review/references/dependency-security.md
@@ -135,16 +135,20 @@ npx can-i-ignore-scripts
 
 ### Dependency Confusion
 Attackers publish public packages with the same name as internal packages.
+When a package name is unclaimed on the public registry, anyone can publish
+malicious code under that name — never reference unclaimed package names in
+documentation or install commands.
 
 **Prevention:**
 ```bash
-# Use scoped packages for internal libraries
-npm install @my-org/internal-lib
-
-# Configure .npmrc for private registry
+# Example: configure .npmrc to resolve scoped packages from a private registry
+# (using Microsoft's real public registry as illustration only)
 registry=https://registry.npmjs.org/
-@my-org:registry=https://npm.my-company.com/
+@microsoft:registry=https://npm.pkg.github.com/
 ```
+
+Always verify that any package name referenced in docs or scripts is either
+claimed by your organization or points to an explicit local path (e.g. `./script-name`).
 
 ## Reviewing New Dependencies
 

--- a/plugins/github-spec-kit/.claude-plugin/plugin.json
+++ b/plugins/github-spec-kit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-spec-kit",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "GitHub specification integration and verification",
   "author": {
     "name": "Giuseppe Trisciuoglio",

--- a/tile.json
+++ b/tile.json
@@ -1,6 +1,6 @@
 {
   "name": "giuseppe-trisciuoglio/developer-kit",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": false,
   "summary": "Comprehensive developer toolkit providing reusable skills for Java/Spring Boot, TypeScript/NestJS/React/Next.js, Python, PHP, AWS CloudFormation, AI/RAG, DevOps, and more.",
   "skills": {


### PR DESCRIPTION
## Security Fix — Phantom Package Reference

**Reported by:** Noam at Blue Bear Security

### Problem

The TypeScript dependency security guide (`plugins/developer-kit-typescript/skills/typescript-security-review/references/dependency-security.md`) contained an install command referencing `@my-org/internal-lib` — a package name that is **unclaimed** on the npm public registry.

If someone were to publish a malicious package under that name, users following the documentation could inadvertently install and execute attacker-controlled code.

### Changes

- **Removed** the `npm install @my-org/internal-lib` example command entirely
- **Replaced** with a `.npmrc` configuration example using a real, claimed scope (`@microsoft`) and an explicit disclaimer that it is illustration-only
- **Added** guidance to never reference unclaimed package names in documentation or install commands

### Files Changed

| File | Change |
|------|--------|
| `plugins/developer-kit-typescript/skills/typescript-security-review/references/dependency-security.md` | Removed phantom package, added safe example |
| `CHANGELOG.md` | Added v3.0.1 security entry |
| `*plugin.json`, `marketplace.json`, `tile.json` | Version bump to 3.0.1 |

### Verification

```bash
grep -rn "@my-org" plugins/  # Returns no results
```